### PR TITLE
OpenCVSample : VS warns readme doesnt exist. removing reference from csproj and vcxproj.

### DIFF
--- a/Samples/OpenCVSample/OpenCVSample.Interop/OpenCVSample.Interop.vcxproj
+++ b/Samples/OpenCVSample/OpenCVSample.Interop/OpenCVSample.Interop.vcxproj
@@ -131,9 +131,6 @@ copy $(OpenCVDir)\build\x64\vc14\bin\opencv_world330.dll $(OutDir)..\..\..\OpenC
   <ItemGroup>
     <Image Include="app.ico" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="README.md" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Samples/OpenCVSample/OpenCVSample/OpenCVSample.csproj
+++ b/Samples/OpenCVSample/OpenCVSample/OpenCVSample.csproj
@@ -127,7 +127,6 @@
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
-    <None Include="README.md" />
     <AdditionalFiles Include="stylecop.json" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The README file is one level above and common to both projects. Markdown is not required to be referenced in the project files.