### PR TITLE
Better linux build chain

### DIFF
--- a/Samples/LinuxSpeechSample/Program.cs
+++ b/Samples/LinuxSpeechSample/Program.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Psi.Samples.LinuxSpeechSample
             {
                 // Create the AudioSource component to capture audio from the default device in 16 kHz 1-channel
                 // PCM format as required by both the voice activity detector and speech recognition components.
-                IProducer<AudioBuffer> audioInput = new AudioCapture(pipeline, new AudioCaptureConfiguration() { DeviceName = "plughw:0,0", Format = WaveFormat.Create16kHz1Channel16BitPcm() });
+                IProducer<AudioBuffer> audioInput = new AudioCapture(pipeline, new AudioCaptureConfiguration() { DeviceName = deviceName, Format = WaveFormat.Create16kHz1Channel16BitPcm() });
 
                 // Perform voice activity detection using the voice activity detector component
                 var vad = new SimpleVoiceActivityDetector(pipeline);

--- a/Samples/LinuxSpeechSample/Program.cs
+++ b/Samples/LinuxSpeechSample/Program.cs
@@ -74,6 +74,14 @@ namespace Microsoft.Psi.Samples.LinuxSpeechSample
         /// </remarks>
         public static void RunAzureSpeech()
         {
+            // Get the Device Name to record audio from
+            Console.Write("Enter Device Name (default: plughw:0,0)");
+            string deviceName = Console.ReadLine();
+            if (!string.IsNullOrWhiteSpace(deviceName))
+            {
+                deviceName = "plughw:0,0";
+            }
+
             // Create the pipeline object.
             using (Pipeline pipeline = Pipeline.Create())
             {

--- a/Samples/LinuxSpeechSample/build.sh
+++ b/Samples/LinuxSpeechSample/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+dotnet build ./LinuxSpeechSample.csproj

--- a/Samples/RosTurtleSample/build.sh
+++ b/Samples/RosTurtleSample/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-dotnet build ./PsiRosTurtleSample.csproj
+dotnet build ./RosTurtleSample.csproj

--- a/Sources/Media/Microsoft.Psi.Media.Native.x64/build.sh
+++ b/Sources/Media/Microsoft.Psi.Media.Native.x64/build.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 
-make
+if [[ -z "${FFMPEGDir}" ]]; then
+    echo "FFMPEGDir Environment Variable Not Defined. Skipping Microsoft.Psi.Media.Native.x64"
+    # Future implementation might consider finding the library's path instead of needing to be predefined.
+    # If install using the package manager, the libs are located at /usr/lib/x86_64-linux-gnu/ and headers
+    # are at /usr/include/x86_64-linux-gnu/
+else
+    make
+fi

--- a/build.sh
+++ b/build.sh
@@ -21,4 +21,5 @@
 (cd ./Sources/Runtime/Test.Psi/                                                        && . ./build.sh)
 (cd ./Sources/Toolkits/FiniteStateMachine/Microsoft.Psi.FiniteStateMachine/            && . ./build.sh)
 (cd ./Sources/Tools/PsiStoreTool/                                                      && . ./build.sh)
-(cd ./Samples/PsiRosTurtleSample/                                                      && . ./build.sh)
+(cd ./Samples/RosTurtleSample/                                                         && . ./build.sh)
+(cd ./Samples/LinuxSpeechSample/                                                       && . ./build.sh)


### PR DESCRIPTION
Fixed the building process of the code base
- Check if FFMPEGDir exists and only build it if it does.
- Fixed misspelling of one of the packages.
- Added LinuxSpeechSample to the build chain.
- Added ability to specify the audio device in the LinuxSpeechSample.
- Feel free to copy and paste the instructions to build on Linux from here:
https://github.com/xiangzhi/RosBag2PsiStoreConverter/wiki/Installing-and-%5CPsi-Codebase-on-Ubuntu-18.04

Remaining Problem
- I wasn't able to get the LinuxSpeechSample to work, the audio capture only capture garbage. It might be a setting problem.