### PR TITLE
Fix PsiStudio 3D Visualization crash

### DIFF
--- a/Sources/Visualization/Microsoft.Psi.Visualization.Common.Windows/Views/VisualizationContainerView.xaml
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Common.Windows/Views/VisualizationContainerView.xaml
@@ -45,6 +45,7 @@
             HeadersVisibility="None"
             HorizontalContentAlignment="Stretch"            
             HorizontalScrollBarVisibility="Disabled"
+            IsReadOnly="True"
             ItemsSource="{Binding Panels}"
             RowBackground="Transparent"
             SelectionMode="Single"


### PR DESCRIPTION
Made DataGrid view in VisualizationContainerView read-only so that it does not attempt to respond to mouse click routed events which bubble up. Fixes #71 