### PR TITLE
Fixed bug where loading layout at startup sometimes crashed

### DIFF
--- a/Sources/Tools/PsiStudio/Microsoft.Psi.PsiStudio/MainWindowViewModel.cs
+++ b/Sources/Tools/PsiStudio/Microsoft.Psi.PsiStudio/MainWindowViewModel.cs
@@ -1016,7 +1016,7 @@ namespace Microsoft.Psi.PsiStudio
                     this.AppSettings.CurrentLayoutName = this.currentLayout.Name;
                 }
 
-                if (this.currentLayout != null)
+                if (this.currentLayout != null && this.isInitialized)
                 {
                     this.OpenCurrentLayout();
                 }


### PR DESCRIPTION
When PsiStudio starts up, if the user has 3rd party assemblies specified and classes within them are used in the current layout, PsiStudio will attempt to load the layout before the 3rd party assemblies have finished loading. This causes an error which we attempt to display in a dialog window, we get an unhandled exception because we're trying to set the parent window of the dialog to the main window, but the main window has not yet been rendered.

Updated the code so that when setting the CurrentLayout property, we don't try to load the layout if we've not yet finished initializing.  Once the MainWindow has been shown, we then attempt to open the current layout and everything succeeds.