### PR TITLE
Preserve timing button states when switching layouts

### DIFF
--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Navigation/Navigator.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Navigation/Navigator.cs
@@ -381,6 +381,10 @@ namespace Microsoft.Psi.Visualization.Navigation
             this.ViewRange.SetRange(navigator.ViewRange.AsTimeInterval);
             this.SelectionRange.SetRange(navigator.SelectionRange.AsTimeInterval);
             this.Cursor = navigator.Cursor;
+            this.ShowAbsoluteTiming = navigator.ShowAbsoluteTiming;
+            this.ShowTimingRelativeToSessionStart = navigator.ShowTimingRelativeToSessionStart;
+            this.ShowTimingRelativeToSelectionStart = navigator.ShowTimingRelativeToSelectionStart;
+            this.CursorFollowsMouse = navigator.CursorFollowsMouse;
         }
 
         /// <summary>


### PR DESCRIPTION
When switching layouts, we now preserve the button states in PsiStudio for the following settings:

Show Absolute Timing
Show Timing Relative To Session Start
Show Timing Relative To Selection Start
Cursor Follows Mouse

I believe this constitutes all of the toolbar button settings that need to be preserved when we create a new Navigator on layout change.
