### PR TITLE
bug fixes to camera intrinsics and depth camera view as point cloud viz

### DIFF
--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/VisualizationObjects/SpatialDepthCameraViewAsPointCloudVisualizationObject.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/VisualizationObjects/SpatialDepthCameraViewAsPointCloudVisualizationObject.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Psi.Visualization.VisualizationObjects
         /// </summary>
         [DataMember]
         [DisplayName("Point Cloud Sparsity")]
-        [Description("The sparsity (in pixels) of the point cloud.")]
+        [Description("The sparsity (in pixels) of the point cloud (min=1).")]
         public int Sparsity
         {
             get { return this.sparsity; }
-            set { this.Set(nameof(this.Sparsity), ref this.sparsity, value); }
+            set { this.Set(nameof(this.Sparsity), ref this.sparsity, value > 0 ? value : 1); }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
- The constructor for `CameraIntrinsics` now checks for a valid 3x3 transform matrix. Radial distortion coefficients are initialized as a vector of length 6, copying over however many are passed to the constructor. Same for tangential distortion coefficients (but length=2).
Fixes #107 
- Fixed a small bug in `SpatialDepthCameraViewAsPointCloudVisualizationObject` to not allow the Point Cloud Sparsity property to take any value lower than 1.