### PR TITLE
Added helper for constructing `StructDefs` from C#

### DIFF
--- a/Sources/Integrations/ROS/Microsoft.Psi.ROS/RosMessage.fs
+++ b/Sources/Integrations/ROS/Microsoft.Psi.ROS/RosMessage.fs
@@ -170,5 +170,7 @@ module RosMessage =
                                                              MD5          = md5
                                                              CallFields   = List.ofSeq callFields
                                                              ReturnFields = List.ofSeq returnFields }
+                                                             
+    let CreateStructDef def = StructDef (def.Fields)
 
     let malformed () = failwith "Malformed message structure"

--- a/Sources/Integrations/ROS/Microsoft.Psi.ROS/RosMessage.fs
+++ b/Sources/Integrations/ROS/Microsoft.Psi.ROS/RosMessage.fs
@@ -172,5 +172,11 @@ module RosMessage =
                                                              ReturnFields = List.ofSeq returnFields }
                                                              
     let CreateStructDef def = StructDef (def.Fields)
+    
+    let CreateStructVal fields = StructVal (List.ofSeq fields)
+
+    let CreateVariableArrayVal vals = VariableArrayVal (List.ofSeq vals)
+
+    let CreatFixedArrayVal vals = FixedArrayVal (List.ofSeq vals)
 
     let malformed () = failwith "Malformed message structure"


### PR DESCRIPTION
The `NewStructDef()` constructors generated by F# works in C# (e.g. `RosMessage.RosFieldDef.NewStructDef(someMessageDef.Fields)`) but requires referencing `FSharp.Core`. This change adds a `CreateStructDef(...)` constructor taking the `MessageDef` directly (e.g. `RosMessage.CreateStructDef(someMessageDef)`), as well as a `CreateStructVal(...)` constructor and constructors for `Variable/FixedArrayVal`.