### PR TITLE
Fix bug in nanosecond conversion in ROS component.

### DIFF
--- a/Sources/Integrations/ROS/Microsoft.Psi.ROS/RosMessage.fs
+++ b/Sources/Integrations/ROS/Microsoft.Psi.ROS/RosMessage.fs
@@ -144,13 +144,13 @@ module RosMessage =
     let toDateTime (sec: uint32) (nsec: uint32) = (new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).AddSeconds(float sec).AddMilliseconds(float nsec / 1000000.0)
     let fromDateTime (dt: DateTime) =
         let sec = dt.Subtract(new DateTime(1970, 1, 1, 0, 0, 0)).TotalSeconds
-        let nsec = (sec - Math.Truncate(sec)) * 1000000.0
+        let nsec = (sec - Math.Truncate(sec)) * 1000000000.0
         uint32 sec, uint32 nsec
 
     let toTimeSpan sec nsec = (new TimeSpan(0, 0, 0, sec, nsec / 1000000))
     let fromTimeSpan (ts: TimeSpan) =
         let sec = ts.TotalSeconds
-        let nsec = (sec - Math.Truncate(sec)) * 1000000.0
+        let nsec = (sec - Math.Truncate(sec)) * 1000000000.0
         int sec, int nsec
         
     type MessageDef = { Type:   string


### PR DESCRIPTION
This PR fixes a bug where when converting `DateTime` to `Time` in ROS, the `nsec` of Time was converted to microsecond (10e-6) instead of nanoseconds (10e-9)