### PR TITLE
Capture cursor time when menu item is created

### DIFF
--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Navigation/Navigator.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Navigation/Navigator.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Psi.Visualization.Navigation
         // True if the timeline cursor should follow the mouse cursor when in manual navigation mode, otherwise false
         private bool cursorFollowsMouse = true;
 
-        private RelayCommand copyCursorTimeToClipboardCommand;
+        private RelayCommand<DateTime> copyCursorTimeToClipboardCommand;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Navigator"/> class.
@@ -105,8 +105,8 @@ namespace Microsoft.Psi.Visualization.Navigation
         /// </summary>
         [Browsable(false)]
         [IgnoreDataMember]
-        public RelayCommand CopyCursorTimeToClipboardCommand
-            => this.copyCursorTimeToClipboardCommand ??= new RelayCommand(() => Clipboard.SetText(this.Cursor.ToString("M/d/yyyy HH:mm:ss.ffff")));
+        public RelayCommand<DateTime> CopyCursorTimeToClipboardCommand
+            => this.copyCursorTimeToClipboardCommand ??= new RelayCommand<DateTime>(cursor => Clipboard.SetText(cursor.ToString("M/d/yyyy HH:mm:ss.ffff")));
 
         /// <summary>
         /// Gets or the cursor mode.

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Views/VisualizationPanelView.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Views/VisualizationPanelView.cs
@@ -48,10 +48,11 @@ namespace Microsoft.Psi.Visualization.Views
                 menuItems.Add(
                     MenuItemHelper.CreateMenuItem(
                         null,
-                        $"Copy Cursor Times to Clipboard",
+                        $"Copy Cursor Time to Clipboard",
                         visualizationPanel.Navigator.CopyCursorTimeToClipboardCommand,
                         null,
-                        true));
+                        true,
+                        visualizationPanel.Navigator.Cursor));
             }
         }
     }


### PR DESCRIPTION
Fixes an issue where captured cursor time is sometimes incorrect due to the cursor jumping to the current position if the Copy Cursor Time to Clipboard context menu item is clicked while over a timeline panel.