### PR TITLE
PhotoVideoCamera Intrinsics per Frame

### DIFF
--- a/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/PhotoVideoCamera.cs
+++ b/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/PhotoVideoCamera.cs
@@ -481,9 +481,6 @@ namespace Microsoft.Psi.MixedReality
             Emitter<CoordinateSystem> poseStream,
             Emitter<EncodedImageCameraView> encodedImageCameraViewStream)
         {
-            // Cache the intrinsics
-            ICameraIntrinsics cameraIntrinsics = null;
-
             return (sender, args) =>
             {
                 using var frame = sender.TryAcquireLatestFrame();
@@ -494,7 +491,8 @@ namespace Microsoft.Psi.MixedReality
                     var originatingTime = this.pipeline.GetCurrentTimeFromElapsedTicks(frameTimestamp);
 
                     // Compute the camera intrinsics if needed
-                    if (cameraIntrinsics == null && streamSettings.OutputCameraIntrinsics)
+                    var cameraIntrinsics = default(ICameraIntrinsics);
+                    if (streamSettings.OutputCameraIntrinsics || streamSettings.OutputEncodedImageCameraView)
                     {
                         cameraIntrinsics = this.GetCameraIntrinsics(frame);
                     }


### PR DESCRIPTION
Small fix to re-create the HoloLens PhotoVideoCamera's `CameraIntrinsics` every frame, rather than just once and caching, because parameters might change over time (particularly focal length being changed due to auto-focus).