### PR TITLE
Various runtime changes affecting throttling and synchronous message delivery

### DIFF
--- a/Sources/Audio/Microsoft.Psi.Audio.Windows/AudioCapture.cs
+++ b/Sources/Audio/Microsoft.Psi.Audio.Windows/AudioCapture.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Psi.Audio
             this.name = name;
             this.configuration = configuration;
             this.audioBuffers = pipeline.CreateEmitter<AudioBuffer>(this, "AudioBuffers");
-            this.AudioLevelInput = pipeline.CreateReceiver<double>(this, this.SetAudioLevel, nameof(this.AudioLevelInput), true);
+            this.AudioLevelInput = pipeline.CreateReceiver<double>(this, this.SetAudioLevel, nameof(this.AudioLevelInput));
             this.AudioLevel = pipeline.CreateEmitter<double>(this, nameof(this.AudioLevel));
 
             this.wasapiCapture = new WasapiCapture();
@@ -154,11 +154,11 @@ namespace Microsoft.Psi.Audio
         /// Sets the audio level.
         /// </summary>
         /// <param name="level">The audio level.</param>
-        public void SetAudioLevel(Message<double> level)
+        public void SetAudioLevel(double level)
         {
             if (this.wasapiCapture != null)
             {
-                this.wasapiCapture.AudioLevel = level.Data;
+                this.wasapiCapture.AudioLevel = level;
             }
         }
 

--- a/Sources/Integrations/MicrosoftSpeech/Microsoft.Psi.MicrosoftSpeech.Windows/MicrosoftSpeechIntentDetector.cs
+++ b/Sources/Integrations/MicrosoftSpeech/Microsoft.Psi.MicrosoftSpeech.Windows/MicrosoftSpeechIntentDetector.cs
@@ -47,10 +47,10 @@ namespace Microsoft.Psi.MicrosoftSpeech
             this.Configuration = configuration;
 
             // create receiver of grammar updates
-            this.ReceiveGrammars = pipeline.CreateReceiver<IEnumerable<string>>(this, this.SetGrammars, nameof(this.ReceiveGrammars), true);
+            this.ReceiveGrammars = pipeline.CreateReceiver<IEnumerable<string>>(this, this.SetGrammars, nameof(this.ReceiveGrammars));
 
             // create receiver of grammar updates by name
-            this.ReceiveGrammarNames = pipeline.CreateReceiver<string[]>(this, this.EnableGrammars, nameof(this.ReceiveGrammarNames), true);
+            this.ReceiveGrammarNames = pipeline.CreateReceiver<string[]>(this, this.EnableGrammars, nameof(this.ReceiveGrammarNames));
 
             // create output streams for all the event args
             this.LoadGrammarCompleted = pipeline.CreateEmitter<LoadGrammarCompletedEventArgs>(this, nameof(LoadGrammarCompletedEventArgs));
@@ -95,9 +95,9 @@ namespace Microsoft.Psi.MicrosoftSpeech
         /// Replace grammars with given.
         /// </summary>
         /// <param name="srgsXmlGrammars">A collection of XML-format speech grammars that conform to the SRGS 1.0 specification.</param>
-        public void SetGrammars(Message<IEnumerable<string>> srgsXmlGrammars)
+        public void SetGrammars(IEnumerable<string> srgsXmlGrammars)
         {
-            this.speechRecognitionEngine.RequestRecognizerUpdate(srgsXmlGrammars.Data.Select(g =>
+            this.speechRecognitionEngine.RequestRecognizerUpdate(srgsXmlGrammars.Select(g =>
             {
                 using (var xmlReader = XmlReader.Create(new StringReader(g)))
                 {
@@ -110,11 +110,11 @@ namespace Microsoft.Psi.MicrosoftSpeech
         /// Enable all the grammars indicated by name, disabling all others.
         /// </summary>
         /// <param name="grammarNames">Speech grammars.</param>
-        public void EnableGrammars(Message<string[]> grammarNames)
+        public void EnableGrammars(string[] grammarNames)
         {
             foreach (var g in this.speechRecognitionEngine.Grammars)
             {
-                g.Enabled = grammarNames.Data.Contains(g.Name) ? true : false;
+                g.Enabled = grammarNames.Contains(g.Name) ? true : false;
             }
         }
 

--- a/Sources/Integrations/MicrosoftSpeech/Microsoft.Psi.MicrosoftSpeech.Windows/MicrosoftSpeechRecognizer.cs
+++ b/Sources/Integrations/MicrosoftSpeech/Microsoft.Psi.MicrosoftSpeech.Windows/MicrosoftSpeechRecognizer.cs
@@ -77,10 +77,10 @@ namespace Microsoft.Psi.MicrosoftSpeech
             this.Configuration = configuration ?? new MicrosoftSpeechRecognizerConfiguration();
 
             // create receiver of grammar updates
-            this.ReceiveGrammars = pipeline.CreateReceiver<IEnumerable<string>>(this, this.SetGrammars, nameof(this.ReceiveGrammars), true);
+            this.ReceiveGrammars = pipeline.CreateReceiver<IEnumerable<string>>(this, this.SetGrammars, nameof(this.ReceiveGrammars));
 
             // create receiver of grammar updates by name
-            this.ReceiveGrammarNames = pipeline.CreateReceiver<string[]>(this, this.EnableGrammars, nameof(this.ReceiveGrammarNames), true);
+            this.ReceiveGrammarNames = pipeline.CreateReceiver<string[]>(this, this.EnableGrammars, nameof(this.ReceiveGrammarNames));
 
             // assign the default Out emitter to the RecognitionResults group
             this.originatingTimeConsistencyCheckGroup.Add(this.Out, EmitterGroup.RecognitionResults);
@@ -228,9 +228,9 @@ namespace Microsoft.Psi.MicrosoftSpeech
         /// Replace grammars with given.
         /// </summary>
         /// <param name="srgsXmlGrammars">A collection of XML-format speech grammars that conform to the SRGS 1.0 specification.</param>
-        public void SetGrammars(Message<IEnumerable<string>> srgsXmlGrammars)
+        public void SetGrammars(IEnumerable<string> srgsXmlGrammars)
         {
-            this.speechRecognitionEngine.RequestRecognizerUpdate(srgsXmlGrammars.Data.Select(g =>
+            this.speechRecognitionEngine.RequestRecognizerUpdate(srgsXmlGrammars.Select(g =>
             {
                 using (var xmlReader = XmlReader.Create(new StringReader(g)))
                 {
@@ -243,11 +243,11 @@ namespace Microsoft.Psi.MicrosoftSpeech
         /// Enable all the grammars indicated by name, disabling all others.
         /// </summary>
         /// <param name="grammarNames">Speech grammars.</param>
-        public void EnableGrammars(Message<string[]> grammarNames)
+        public void EnableGrammars(string[] grammarNames)
         {
             foreach (var g in this.speechRecognitionEngine.Grammars)
             {
-                g.Enabled = grammarNames.Data.Contains(g.Name) ? true : false;
+                g.Enabled = grammarNames.Contains(g.Name) ? true : false;
             }
         }
 

--- a/Sources/MixedReality/HoloLensCapture/HoloLensCaptureExporter/Operators.cs
+++ b/Sources/MixedReality/HoloLensCapture/HoloLensCaptureExporter/Operators.cs
@@ -222,8 +222,7 @@ namespace HoloLensCaptureExporter
                         }
 
                         imageCounter++;
-                    },
-                    DeliveryPolicy.SynchronousOrThrottle);
+                    });
         }
 
         /// <summary>
@@ -249,7 +248,7 @@ namespace HoloLensCaptureExporter
 
             var depthImageCounter = 0;
             source
-                .Encode(new DepthImageToPngStreamEncoder(), DeliveryPolicy.SynchronousOrThrottle)
+                .Encode(new DepthImageToPngStreamEncoder())
                 .Do(
                     (edicv, envelope) =>
                     {
@@ -266,8 +265,7 @@ namespace HoloLensCaptureExporter
                         }
 
                         depthImageCounter++;
-                    },
-                    DeliveryPolicy.SynchronousOrThrottle);
+                    });
         }
 
         /// <summary>
@@ -288,8 +286,7 @@ namespace HoloLensCaptureExporter
                     (vector, envelope) =>
                     {
                         file.WriteLine($"{envelope.OriginatingTime.ToText()}\t{vector.ToText()}");
-                    },
-                    DeliveryPolicy.SynchronousOrThrottle);
+                    });
         }
 
         /// <summary>
@@ -309,8 +306,7 @@ namespace HoloLensCaptureExporter
                     (coordinateSystem, envelope) =>
                     {
                         file.WriteLine($"{envelope.OriginatingTime.ToText()}\t{coordinateSystem.ToText()}");
-                    },
-                    DeliveryPolicy.SynchronousOrThrottle);
+                    });
         }
 
         /// <summary>
@@ -330,8 +326,7 @@ namespace HoloLensCaptureExporter
                     (ray3D, envelope) =>
                     {
                         file.WriteLine($"{envelope.OriginatingTime.ToText()}\t{ray3D.ToText()}");
-                    },
-                    DeliveryPolicy.SynchronousOrThrottle);
+                    });
         }
 
         /// <summary>
@@ -365,8 +360,7 @@ namespace HoloLensCaptureExporter
                         }
 
                         file.WriteLine(result.ToString().TrimEnd('\t'));
-                    },
-                    DeliveryPolicy.SynchronousOrThrottle);
+                    });
         }
 
         /// <summary>
@@ -382,8 +376,7 @@ namespace HoloLensCaptureExporter
             source.PipeTo(
                 new WaveFileWriter(
                     source.Out.Pipeline,
-                    DataExporter.EnsurePathExists(Path.Combine(outputPath, name, $"{name}.wav"))),
-                DeliveryPolicy.SynchronousOrThrottle);
+                    DataExporter.EnsurePathExists(Path.Combine(outputPath, name, $"{name}.wav"))));
 
             // export individual raw audio buffers to `Audio000123.bin` files along with timing information
             var buffersPath = Path.Combine(outputPath, name, "Buffers");
@@ -404,8 +397,7 @@ namespace HoloLensCaptureExporter
                             file.Dispose();
                             timingFile.WriteLine($"{bufferCounter++}\t{envelope.OriginatingTime.ToText()}");
                         }
-                    },
-                    DeliveryPolicy.SynchronousOrThrottle);
+                    });
         }
 
         /// <summary>
@@ -435,8 +427,7 @@ namespace HoloLensCaptureExporter
                         }
 
                         file.WriteLine(result.ToString().TrimEnd('\t'));
-                    },
-                    DeliveryPolicy.SynchronousOrThrottle);
+                    });
         }
 
         /// <summary>
@@ -521,8 +512,7 @@ namespace HoloLensCaptureExporter
                             meshesFile.WriteLine($"{originatingTime}\t{s.Meshes.Count}\t{s.ColliderMeshes.Count}");
                             ExportMeshes(s.Meshes, nameof(SceneObjectCollection.SceneObject.Meshes), originatingTime);
                             ExportMeshes(s.ColliderMeshes, nameof(SceneObjectCollection.SceneObject.ColliderMeshes), originatingTime);
-                        },
-                        DeliveryPolicy.SynchronousOrThrottle);
+                        });
             }
 
             ExportScene(source.Select(s => s.Background), nameof(SceneObjectCollection.Background));

--- a/Sources/Runtime/Microsoft.Psi/Common/DeliveryPolicy{T}.cs
+++ b/Sources/Runtime/Microsoft.Psi/Common/DeliveryPolicy{T}.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Psi
         /// <param name="initialQueueSize">The initial receiver queue size.</param>
         /// <param name="maximumQueueSize">The maximum receiver queue size.</param>
         /// <param name="maximumLatency">The maximum latency allowable for messages to be delivered.</param>
-        /// <param name="throttleWhenFull">A value indicating whether to block the upstream producer if the receiver queue is full.</param>
+        /// <param name="throttleQueueSize">The number of messages in the receiver queue at and above which the upstream producer will be blocked.</param>
         /// <param name="attemptSynchronous">A value indicating whether to attempt synchronous delivery.</param>
         /// <param name="guaranteeDelivery">A function that indicates for which messages delivery should be guaranteed.</param>
         /// <param name="name">Name used for debugging and diagnostics.</param>
@@ -25,7 +25,7 @@ namespace Microsoft.Psi
             int initialQueueSize = DeliveryPolicy.DefaultInitialQueueSize,
             int maximumQueueSize = int.MaxValue,
             TimeSpan? maximumLatency = null,
-            bool throttleWhenFull = false,
+            int? throttleQueueSize = null,
             bool attemptSynchronous = false,
             Func<T, bool> guaranteeDelivery = null,
             string name = null)
@@ -33,17 +33,17 @@ namespace Microsoft.Psi
             this.InitialQueueSize = initialQueueSize;
             this.MaximumQueueSize = maximumQueueSize;
             this.MaximumLatency = maximumLatency;
-            this.ThrottleWhenFull = throttleWhenFull;
+            this.ThrottleQueueSize = throttleQueueSize;
             this.AttemptSynchronousDelivery = attemptSynchronous;
             this.GuaranteeDelivery = guaranteeDelivery;
-            this.Name = name ?? $"{nameof(DeliveryPolicy<T>)}({nameof(initialQueueSize)}={initialQueueSize}, {nameof(maximumQueueSize)}={maximumQueueSize}, {nameof(maximumLatency)}={maximumLatency}, {nameof(throttleWhenFull)}={throttleWhenFull}, {nameof(attemptSynchronous)}={attemptSynchronous})";
+            this.Name = name ?? $"{nameof(DeliveryPolicy<T>)}({nameof(initialQueueSize)}={initialQueueSize}, {nameof(maximumQueueSize)}={maximumQueueSize}, {nameof(maximumLatency)}={maximumLatency}, {nameof(throttleQueueSize)}={throttleQueueSize}, {nameof(attemptSynchronous)}={attemptSynchronous})";
         }
 
         /// <summary>
-        /// Gets a value indicating whether to block the upstream producer if the receiver queue is full.
+        /// Gets the number of messages in the receiver queue at and above which the upstream producer will be blocked.
         /// </summary>
         /// <remarks>Use with care, as it affects all other subscribers to the same producer and can introduce deadlocks (a blocked producer cannot process control messages anymore).</remarks>
-        public bool ThrottleWhenFull { get; private set; }
+        public int? ThrottleQueueSize { get; private set; }
 
         /// <summary>
         /// Gets the initial size of the receiver queue that holds the messages pending delivery.
@@ -85,7 +85,7 @@ namespace Microsoft.Psi
                 policy.InitialQueueSize,
                 policy.MaximumQueueSize,
                 policy.MaximumLatency,
-                policy.ThrottleWhenFull,
+                policy.ThrottleQueueSize,
                 policy.AttemptSynchronousDelivery,
                 null,
                 policy.Name);
@@ -102,7 +102,7 @@ namespace Microsoft.Psi
                 DeliveryPolicy.DefaultInitialQueueSize,
                 this.MaximumQueueSize,
                 this.MaximumLatency,
-                this.ThrottleWhenFull,
+                this.ThrottleQueueSize,
                 this.AttemptSynchronousDelivery,
                 this.GuaranteeDelivery == null ? guaranteeDelivery : t => this.GuaranteeDelivery(t) || guaranteeDelivery(t),
                 $"{this.Name}.WithGuarantees");

--- a/Sources/Runtime/Microsoft.Psi/Components/Zip.cs
+++ b/Sources/Runtime/Microsoft.Psi/Components/Zip.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Psi.Components
             try
             {
                 Receiver<T> receiver = null; // captured in receiver action closure
-                receiver = this.pipeline.CreateReceiver<T>(this, (m, e) => this.Receive(m, e, receiver.Recycler), name, true);
+                receiver = this.pipeline.CreateReceiver<T>(this, (m, e) => this.Receive(m, e, receiver.Recycler), name);
                 receiver.Unsubscribed += _ => this.Publish();
                 this.inputs.Add(receiver);
                 return receiver;
@@ -64,8 +64,9 @@ namespace Microsoft.Psi.Components
         /// <inheritdoc/>
         public override string ToString() => this.name;
 
-        private void Receive(T clonedData, Envelope envelope, IRecyclingPool<T> recycler)
+        private void Receive(T data, Envelope envelope, IRecyclingPool<T> recycler)
         {
+            var clonedData = data.DeepClone(recycler);
             this.buffer.Add((data: clonedData, envelope, recycler));
             this.Publish();
         }

--- a/Sources/Runtime/Microsoft.Psi/Executive/Pipeline.cs
+++ b/Sources/Runtime/Microsoft.Psi/Executive/Pipeline.cs
@@ -349,11 +349,10 @@ namespace Microsoft.Psi
         /// The receivers associated with the same owner are never executed concurrently.</param>
         /// <param name="action">The action to execute when a message is delivered to this receiver.</param>
         /// <param name="name">The debug name of the receiver.</param>
-        /// <param name="autoClone">If true, the receiver will clone the message before passing it to the action, which is then responsible for recycling it as needed (using receiver.Recycle).</param>
         /// <returns>A new receiver.</returns>
-        public Receiver<T> CreateReceiver<T>(object owner, Action<T, Envelope> action, string name, bool autoClone = false)
+        public Receiver<T> CreateReceiver<T>(object owner, Action<T, Envelope> action, string name)
         {
-            return this.CreateReceiver<T>(owner, m => action(m.Data, m.Envelope), name, autoClone);
+            return this.CreateReceiver<T>(owner, m => action(m.Data, m.Envelope), name);
         }
 
         /// <summary>
@@ -364,11 +363,10 @@ namespace Microsoft.Psi
         /// The receivers associated with the same owner are never executed concurrently.</param>
         /// <param name="action">The action to execute when a message is delivered to this receiver.</param>
         /// <param name="name">The debug name of the receiver.</param>
-        /// <param name="autoClone">If true, the receiver will clone the message before passing it to the action, which is then responsible for recycling it as needed (using receiver.Recycle).</param>
         /// <returns>A new receiver.</returns>
-        public Receiver<T> CreateReceiver<T>(object owner, Action<T> action, string name, bool autoClone = false)
+        public Receiver<T> CreateReceiver<T>(object owner, Action<T> action, string name)
         {
-            return this.CreateReceiver<T>(owner, m => action(m.Data), name, autoClone);
+            return this.CreateReceiver<T>(owner, m => action(m.Data), name);
         }
 
         /// <summary>
@@ -379,12 +377,11 @@ namespace Microsoft.Psi
         /// The receivers associated with the same owner are never executed concurrently.</param>
         /// <param name="action">The action to execute when a message is delivered to this receiver.</param>
         /// <param name="name">The debug name of the receiver.</param>
-        /// <param name="autoClone">If true, the receiver will clone the message before passing it to the action, which is then responsible for recycling it as needed (using receiver.Recycle).</param>
         /// <returns>A new receiver.</returns>
-        public Receiver<T> CreateReceiver<T>(object owner, Action<Message<T>> action, string name, bool autoClone = false)
+        public Receiver<T> CreateReceiver<T>(object owner, Action<Message<T>> action, string name)
         {
             PipelineElement node = this.GetOrCreateNode(owner);
-            var receiver = new Receiver<T>(Interlocked.Increment(ref lastReceiverId), name, node, owner, action, node.SyncContext, this, autoClone);
+            var receiver = new Receiver<T>(Interlocked.Increment(ref lastReceiverId), name, node, owner, action, node.SyncContext, this);
             node.AddInput(name, receiver);
             return receiver;
         }
@@ -398,11 +395,10 @@ namespace Microsoft.Psi
         /// The receivers associated with the same owner are never executed concurrently.</param>
         /// <param name="action">The action to execute when a message is delivered to this receiver.</param>
         /// <param name="name">The debug name of the receiver.</param>
-        /// <param name="autoClone">If true, the receiver will clone the message before passing it to the action, which is then responsible for recycling it as needed (using receiver.Recycle).</param>
         /// <returns>A new receiver.</returns>
-        public Receiver<T> CreateAsyncReceiver<T>(object owner, Func<T, Envelope, Task> action, string name, bool autoClone = false)
+        public Receiver<T> CreateAsyncReceiver<T>(object owner, Func<T, Envelope, Task> action, string name)
         {
-            return this.CreateReceiver<T>(owner, m => action(m.Data, m.Envelope).Wait(), name, autoClone);
+            return this.CreateReceiver<T>(owner, m => action(m.Data, m.Envelope).Wait(), name);
         }
 
         /// <summary>
@@ -414,11 +410,10 @@ namespace Microsoft.Psi
         /// The receivers associated with the same owner are never executed concurrently.</param>
         /// <param name="action">The action to execute when a message is delivered to this receiver.</param>
         /// <param name="name">The debug name of the receiver.</param>
-        /// <param name="autoClone">If true, the receiver will clone the message before passing it to the action, which is then responsible for recycling it as needed (using receiver.Recycle).</param>
         /// <returns>A new receiver.</returns>
-        public Receiver<T> CreateAsyncReceiver<T>(object owner, Func<T, Task> action, string name, bool autoClone = false)
+        public Receiver<T> CreateAsyncReceiver<T>(object owner, Func<T, Task> action, string name)
         {
-            return this.CreateReceiver<T>(owner, m => action(m.Data).Wait(), name, autoClone);
+            return this.CreateReceiver<T>(owner, m => action(m.Data).Wait(), name);
         }
 
         /// <summary>
@@ -430,11 +425,10 @@ namespace Microsoft.Psi
         /// The receivers associated with the same owner are never executed concurrently.</param>
         /// <param name="action">The action to execute when a message is delivered to this receiver.</param>
         /// <param name="name">The debug name of the receiver.</param>
-        /// <param name="autoClone">If true, the receiver will clone the message before passing it to the action, which is then responsible for recycling it as needed (using receiver.Recycle).</param>
         /// <returns>A new receiver.</returns>
-        public Receiver<T> CreateAsyncReceiver<T>(object owner, Func<Message<T>, Task> action, string name, bool autoClone = false)
+        public Receiver<T> CreateAsyncReceiver<T>(object owner, Func<Message<T>, Task> action, string name)
         {
-            return this.CreateReceiver<T>(owner, m => action(m).Wait(), name, autoClone);
+            return this.CreateReceiver<T>(owner, m => action(m).Wait(), name);
         }
 
         /// <summary>

--- a/Sources/Runtime/Microsoft.Psi/Streams/DeliveryQueue.cs
+++ b/Sources/Runtime/Microsoft.Psi/Streams/DeliveryQueue.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Psi.Streams
 
             // update the local variables.
             this.isEmpty = count == 0;
-            this.isThrottling = this.policy.ThrottleWhenFull && count >= this.policy.MaximumQueueSize;
+            this.isThrottling = this.policy.ThrottleQueueSize.HasValue && count >= this.policy.ThrottleQueueSize.Value;
             this.nextMessageEnvelope = (count == 0) ? default : this.queue.Peek().Envelope;
 
             // create the Transition object by comparing the current and previous local state variables.

--- a/Sources/Runtime/Test.Psi/EmitterTester.cs
+++ b/Sources/Runtime/Test.Psi/EmitterTester.cs
@@ -15,7 +15,7 @@ namespace Test.Psi
     public class EmitterTester
     {
         // make out local version of immediate, to make sure it's synchronous even in debug builds
-        private static readonly DeliveryPolicy Immediate = new DeliveryPolicy(1, int.MaxValue, null, true, true);
+        private static readonly DeliveryPolicy Immediate = new DeliveryPolicy(1, int.MaxValue, null, null, true);
 
         [TestMethod]
         [Timeout(60000)]

--- a/Sources/Runtime/Test.Psi/EmitterTester.cs
+++ b/Sources/Runtime/Test.Psi/EmitterTester.cs
@@ -9,13 +9,28 @@ namespace Test.Psi
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Psi;
+    using Microsoft.Psi.Executive;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class EmitterTester
     {
-        // make out local version of immediate, to make sure it's synchronous even in debug builds
+        // custom delivery policy that attempts synchronous delivery for testing purposes
         private static readonly DeliveryPolicy Immediate = new DeliveryPolicy(1, int.MaxValue, null, null, true);
+
+        // maintain our own receiver ids
+        private static int lastReceiverId = -1;
+
+        // creates a custom receiver that does not enforce isolation on synchronous delivery
+        private static Receiver<T> CreateNonIsolatedReceiver<T>(Pipeline pipeline, object owner, Action<Message<T>> action, string name)
+        {
+            PipelineElement node = pipeline.GetOrCreateNode(owner);
+
+            // create custom receivers with a negative receiver id to ensure they do not clash with those created by the public Pipeline methods
+            var receiver = new Receiver<T>(Interlocked.Decrement(ref lastReceiverId), name, node, owner, action, node.SyncContext, pipeline, enforceIsolation: false);
+            node.AddInput(name, receiver);
+            return receiver;
+        }
 
         [TestMethod]
         [Timeout(60000)]
@@ -49,7 +64,8 @@ namespace Test.Psi
             STClass result = null;
             using (var p = Pipeline.Create("ReceiveClassByRef", DeliveryPolicy.Unlimited, allowSchedulingOnExternalThreads: true))
             {
-                var receiver = p.CreateReceiver<STClass>(
+                var receiver = CreateNonIsolatedReceiver<STClass>(
+                    p,
                     this,
                     msg =>
                     {
@@ -101,7 +117,8 @@ namespace Test.Psi
 
             using (var p = Pipeline.Create("ReceiveStructByRef", DeliveryPolicy.Unlimited, allowSchedulingOnExternalThreads: true))
             {
-                var receiver = p.CreateReceiver<STStruct>(
+                var receiver = CreateNonIsolatedReceiver<STStruct>(
+                    p,
                     this,
                     msg =>
                     {

--- a/Sources/Speech/Microsoft.Psi.Speech.Windows/SystemSpeechIntentDetector.cs
+++ b/Sources/Speech/Microsoft.Psi.Speech.Windows/SystemSpeechIntentDetector.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Psi.Speech
             this.speechRecognitionEngine = this.CreateSpeechRecognitionEngine();
 
             // create receivers and emitters
-            this.ReceiveGrammars = pipeline.CreateReceiver<IEnumerable<string>>(this, this.SetGrammars, nameof(this.ReceiveGrammars), true);
+            this.ReceiveGrammars = pipeline.CreateReceiver<IEnumerable<string>>(this, this.SetGrammars, nameof(this.ReceiveGrammars));
             this.LoadGrammarCompleted = pipeline.CreateEmitter<LoadGrammarCompletedEventArgs>(this, nameof(this.LoadGrammarCompleted));
         }
 
@@ -82,9 +82,9 @@ namespace Microsoft.Psi.Speech
         /// Replace grammars with given.
         /// </summary>
         /// <param name="srgsXmlGrammars">A collection of XML-format speech grammars that conform to the SRGS 1.0 specification.</param>
-        public void SetGrammars(Message<IEnumerable<string>> srgsXmlGrammars)
+        public void SetGrammars(IEnumerable<string> srgsXmlGrammars)
         {
-            this.speechRecognitionEngine.RequestRecognizerUpdate(srgsXmlGrammars.Data.Select(g =>
+            this.speechRecognitionEngine.RequestRecognizerUpdate(srgsXmlGrammars.Select(g =>
             {
                 using (var xmlReader = XmlReader.Create(new StringReader(g)))
                 {

--- a/Sources/Speech/Microsoft.Psi.Speech.Windows/SystemSpeechRecognizer.cs
+++ b/Sources/Speech/Microsoft.Psi.Speech.Windows/SystemSpeechRecognizer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Psi.Speech
             this.Configuration = configuration ?? new SystemSpeechRecognizerConfiguration();
 
             // create receiver of grammar updates
-            this.ReceiveGrammars = pipeline.CreateReceiver<IEnumerable<string>>(this, this.SetGrammars, nameof(this.ReceiveGrammars), true);
+            this.ReceiveGrammars = pipeline.CreateReceiver<IEnumerable<string>>(this, this.SetGrammars, nameof(this.ReceiveGrammars));
 
             // assign the default Out emitter to the RecognitionResults group
             this.originatingTimeConsistencyCheckGroup.Add(this.Out, EmitterGroup.RecognitionResults);
@@ -225,9 +225,9 @@ namespace Microsoft.Psi.Speech
         /// Replace grammars with given.
         /// </summary>
         /// <param name="srgsXmlGrammars">A collection of XML-format speech grammars that conform to the SRGS 1.0 specification.</param>
-        public void SetGrammars(Message<IEnumerable<string>> srgsXmlGrammars)
+        public void SetGrammars(IEnumerable<string> srgsXmlGrammars)
         {
-            this.speechRecognitionEngine.RequestRecognizerUpdate(srgsXmlGrammars.Data.Select(g =>
+            this.speechRecognitionEngine.RequestRecognizerUpdate(srgsXmlGrammars.Select(g =>
             {
                 using (var xmlReader = XmlReader.Create(new StringReader(g)))
                 {

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Views/Visuals2D/DiagnosticsVisualization/PipelineDiagnosticsVisualizationPresenter.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Views/Visuals2D/DiagnosticsVisualization/PipelineDiagnosticsVisualizationPresenter.cs
@@ -515,7 +515,7 @@ namespace Microsoft.Psi.Visualization.Views.Visuals2D
             static bool IsLossy(string deliveryPolicyName)
                 => deliveryPolicyName != DeliveryPolicy.Unlimited.Name &&
                    deliveryPolicyName != DeliveryPolicy.SynchronousOrThrottle.Name &&
-                   deliveryPolicyName != DeliveryPolicy.Throttle.Name;
+                   !deliveryPolicyName.StartsWith(nameof(DeliveryPolicy.Throttle));
 
             var edge = new Edge(source, target, ConnectionToGraph.Connected);
             edge.Attr.Color = this.EdgeColor;


### PR DESCRIPTION
- Fixed throttled delivery policies to be lossless.
- Added an adjustable throttling queue size threshold to DeliveryPolicies.
- Modified the HoloLensCapture exporter tool to use throttling with ReplayAll.
- Changed receivers to enforce isolation by default (change only affects synchronous execution).
- Removed the autoClone flag from CreateReceiver methods.