### PR TITLE
UWP MediaCapture: convert NV-12 images to BGRA

### DIFF
--- a/Sources/Imaging/Microsoft.Psi.Imaging/Image.cs
+++ b/Sources/Imaging/Microsoft.Psi.Imaging/Image.cs
@@ -186,6 +186,18 @@ namespace Microsoft.Psi.Imaging
         }
 
         /// <summary>
+        /// Copies the image contents from a memory pointer.
+        /// </summary>
+        /// <param name="source">Memory pointer from which to copy data.</param>
+        /// <param name="size">The maximum number of bytes to copy.</param>
+        /// <remarks><para>The method copies data from the memory pointer into the image.
+        /// The image must be allocated and must have the same size.</para></remarks>
+        public void CopyFrom(IntPtr source, int size)
+        {
+            this.UnmanagedBuffer.CopyFrom(source, size);
+        }
+
+        /// <summary>
         /// Copies the image contents from a specified bitmap.
         /// </summary>
         /// <param name="bitmap">A bitmap to copy from.</param>

--- a/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/MediaCapture/PhotoVideoCamera.cs
+++ b/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/MediaCapture/PhotoVideoCamera.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
         }
 
         /// <summary>
-        /// Gets the RGBA-converted image stream.
+        /// Gets the BGRA-converted image stream.
         /// </summary>
         public Emitter<Shared<Image>> VideoImage { get; }
 
@@ -90,7 +90,7 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
         public Emitter<ICameraIntrinsics> VideoIntrinsics { get; }
 
         /// <summary>
-        /// Gets the RGBA-converted image camera view.
+        /// Gets the BGRA-converted image camera view.
         /// </summary>
         public Emitter<ImageCameraView> VideoImageCameraView { get; }
 
@@ -100,7 +100,7 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
         public Emitter<EncodedImageCameraView> VideoEncodedImageCameraView { get; }
 
         /// <summary>
-        /// Gets the RGBA-converted preview image stream.
+        /// Gets the BGRA-converted preview image stream.
         /// </summary>
         public Emitter<Shared<Image>> PreviewImage { get; }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
         public Emitter<ICameraIntrinsics> PreviewIntrinsics { get; }
 
         /// <summary>
-        /// Gets the preview RGBA-converted image camera view.
+        /// Gets the preview BGRA-converted image camera view.
         /// </summary>
         public Emitter<ImageCameraView> PreviewImageCameraView { get; }
 
@@ -562,7 +562,7 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
 
                         if (streamSettings.OutputImage || streamSettings.OutputImageCameraView)
                         {
-                            using var convertedBitmap = SoftwareBitmap.Convert(frameBitmap, BitmapPixelFormat.Rgba8, BitmapAlphaMode.Ignore);
+                            using var convertedBitmap = SoftwareBitmap.Convert(frameBitmap, BitmapPixelFormat.Bgra8, BitmapAlphaMode.Ignore);
                             using var sharedImage = ImagePool.GetOrCreate(convertedBitmap.PixelWidth, convertedBitmap.PixelHeight, PixelFormat.BGRA_32bpp);
 
                             // Copy bitmap data into the shared image
@@ -572,7 +572,7 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
                                 using var inputReference = input.CreateReference();
                                 ((UnsafeNative.IMemoryBufferByteAccess)inputReference).GetBuffer(out byte* imageData, out uint size);
 
-                                // Copy RGBA bytes directly
+                                // Copy BGRA bytes directly
                                 sharedImage.Resource.CopyFrom((IntPtr)imageData, (int)size);
                             }
 

--- a/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/MediaCapture/PhotoVideoCamera.cs
+++ b/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/MediaCapture/PhotoVideoCamera.cs
@@ -576,13 +576,13 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
                                 sharedImage.Resource.CopyFrom((IntPtr)imageData, (int)size);
                             }
 
-                            // Post encoded image stream
+                            // Post image stream
                             if (streamSettings.OutputImage)
                             {
                                 imageStream.Post(sharedImage, originatingTime);
                             }
 
-                            // Post the encoded image camera view stream if requested
+                            // Post the image camera view stream if requested
                             if (streamSettings.OutputImageCameraView)
                             {
                                 using var imageCameraView = new ImageCameraView(sharedImage, cameraIntrinsics, cameraPose);

--- a/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/MediaCapture/PhotoVideoCameraConfiguration.cs
+++ b/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/MediaCapture/PhotoVideoCameraConfiguration.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
             public int ImageHeight { get; set; } = 720;
 
             /// <summary>
-            /// Gets or sets a value indicating whether the RGBA-converted image is emitted.
+            /// Gets or sets a value indicating whether the BGRA-converted image is emitted.
             /// </summary>
             public bool OutputImage { get; set; } = false;
 
@@ -122,7 +122,7 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
             public bool OutputPose { get; set; } = true;
 
             /// <summary>
-            /// Gets or sets a value indicating whether the RGBA-converted image camera view is emitted.
+            /// Gets or sets a value indicating whether the BGRA-converted image camera view is emitted.
             /// </summary>
             public bool OutputImageCameraView { get; set; } = false;
 

--- a/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/MediaCapture/PhotoVideoCameraConfiguration.cs
+++ b/Sources/MixedReality/Microsoft.Psi.MixedReality.UniversalWindows/MediaCapture/PhotoVideoCameraConfiguration.cs
@@ -102,6 +102,11 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
             public int ImageHeight { get; set; } = 720;
 
             /// <summary>
+            /// Gets or sets a value indicating whether the RGBA-converted image is emitted.
+            /// </summary>
+            public bool OutputImage { get; set; } = false;
+
+            /// <summary>
             /// Gets or sets a value indicating whether the original NV12-encoded image is emitted.
             /// </summary>
             public bool OutputEncodedImage { get; set; } = true;
@@ -115,6 +120,11 @@ namespace Microsoft.Psi.MixedReality.MediaCapture
             /// Gets or sets a value indicating whether the camera pose is emitted.
             /// </summary>
             public bool OutputPose { get; set; } = true;
+
+            /// <summary>
+            /// Gets or sets a value indicating whether the RGBA-converted image camera view is emitted.
+            /// </summary>
+            public bool OutputImageCameraView { get; set; } = false;
 
             /// <summary>
             /// Gets or sets a value indicating whether the original NV12-encoded camera view is emitted.


### PR DESCRIPTION
Hi, sorry opening a different pull request since I accidentally confused RGBA and BGRA formats, so I wanted to change the branch name to reflect that these are BGRA images.

>I noticed that the ImageFromNV12StreamDecoder takes a significant amount of time for each NV12-encoded image. In terms of JPEG compression, it would be nice to skip this decoding prerequisite as mentioned here: https://github.com/microsoft/psi/issues/223#issuecomment-1111201702. The [conversion](https://github.com/microsoft/psi/compare/master...Nakamir-Code:nakamir-psi:feat/uwp-mediacapture-rgba-image?expand=1#diff-6c969abe585f4024ec287ddf2885c70be57038e99194baef229c544cbb77a850R565) to RGBA format with a software bitmap in C# is not the fastest solution on the HoloLens 2, but in my performance tests, it only took about 10 ms per image versus up to 100 ms of decoding time with the ImageFromNV12StreamDecoder. This might be a good option to have for devs, even though a native decoding of the NV-12 format would be even faster. Let me know what you think!