### PR TITLE
fix: dispose the open file handle if disk is full

### DIFF
--- a/Sources/Runtime/Microsoft.Psi/Persistence/InfiniteFileWriter.cs
+++ b/Sources/Runtime/Microsoft.Psi/Persistence/InfiniteFileWriter.cs
@@ -240,7 +240,15 @@ namespace Microsoft.Psi.Persistence
             {
                 this.extentName = System.IO.Path.Combine(this.Path, this.extentName);
                 var file = File.Open(this.extentName, FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
-                newMMF = MemoryMappedFile.CreateFromFile(file, null, this.extentSize, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable, false);
+                try
+                {
+                    newMMF = MemoryMappedFile.CreateFromFile(file, null, this.extentSize, MemoryMappedFileAccess.ReadWrite, HandleInheritability.Inheritable, false);
+                }
+                catch (IOException)
+                {
+                    file.Dispose();
+                    throw;
+                }
             }
             else
             {


### PR DESCRIPTION
When running out of disk space, the call to `MemoryMappedFile.CreateFromFile` throws the following exception: `System.IO.IOException: 'There is not enough space on the disk'`. The file handle still remains open in this case, and doesn't let other processes on the system delete/modify it.