### PR TITLE
Enumerating store files doesn't match filenames with whitespace

### DIFF
--- a/Sources/Runtime/Microsoft.Psi/Persistence/PsiStoreCommon.cs
+++ b/Sources/Runtime/Microsoft.Psi/Persistence/PsiStoreCommon.cs
@@ -73,13 +73,14 @@ namespace Microsoft.Psi.Persistence
 
         internal static IEnumerable<FileInfo> EnumerateStoreFiles(string storeName, string storePath)
         {
+            string escapedStoreName = Regex.Escape(storeName);
             foreach (var fileName in Directory.EnumerateFiles(storePath))
             {
                 var fileInfo = new FileInfo(fileName);
-                if (Regex.Match(fileInfo.Name, $@"^{storeName}\.Catalog_\d\d\d\d\d\d\.psi$").Success ||
-                    Regex.Match(fileInfo.Name, $@"^{storeName}\.Data_\d\d\d\d\d\d\.psi$").Success ||
-                    Regex.Match(fileInfo.Name, $@"^{storeName}\.LargeData_\d\d\d\d\d\d\.psi$").Success ||
-                    Regex.Match(fileInfo.Name, $@"^{storeName}\.Index_\d\d\d\d\d\d\.psi$").Success)
+                if (Regex.Match(fileInfo.Name, $@"^{escapedStoreName}\.Catalog_\d\d\d\d\d\d\.psi$").Success ||
+                    Regex.Match(fileInfo.Name, $@"^{escapedStoreName}\.Data_\d\d\d\d\d\d\.psi$").Success ||
+                    Regex.Match(fileInfo.Name, $@"^{escapedStoreName}\.LargeData_\d\d\d\d\d\d\.psi$").Success ||
+                    Regex.Match(fileInfo.Name, $@"^{escapedStoreName}\.Index_\d\d\d\d\d\d\.psi$").Success)
                 {
                     yield return fileInfo;
                 }


### PR DESCRIPTION
For example, the store name of "recording" works well, but if you have a store called "recording (1)" then the whitespace character was not being properly escaped. Is this something you'd like done internally (e.g., this PR), or is it up to the caller to properly escape the store name string?