### PR TITLE
Make struct layouts explicit

### DIFF
--- a/Sources/Runtime/Microsoft.Psi/Common/Envelope.cs
+++ b/Sources/Runtime/Microsoft.Psi/Common/Envelope.cs
@@ -4,21 +4,25 @@
 namespace Microsoft.Psi
 {
     using System;
+    using System.Runtime.InteropServices;
 
     /// <summary>
     /// Represents the envelope of a message published to a data stream.
     /// See <see cref="Message{T}"/> for details.
     /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
     public struct Envelope
     {
         /// <summary>
         /// The id of the stream that generated the message.
         /// </summary>
+        [FieldOffset(0)]
         public int SourceId;
 
         /// <summary>
         /// The sequence number of this message, unique within the stream identified by <see cref="SourceId"/>.
         /// </summary>
+        [FieldOffset(4)]
         public int SequenceId;
 
         /// <summary>
@@ -26,11 +30,13 @@ namespace Microsoft.Psi
         /// This value is used as a key when synchronizing messages across streams.
         /// This value must be propagated with any message derived from this message.
         /// </summary>
+        [FieldOffset(8)]
         public DateTime OriginatingTime;
 
         /// <summary>
         /// The message creation time.
         /// </summary>
+        [FieldOffset(16)]
         public DateTime CreationTime;
 
         /// <summary>

--- a/Sources/Runtime/Microsoft.Psi/Data/IndexEntry.cs
+++ b/Sources/Runtime/Microsoft.Psi/Data/IndexEntry.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Psi.Data
 {
     using System;
+    using System.Runtime.InteropServices;
 
     /// <summary>
     /// Structure describing a position in a data file.
@@ -21,28 +22,33 @@ namespace Microsoft.Psi.Data
     /// When writing large messages, an index entry is written into the main data file,
     /// pointing to a location in the large data file where the actual message resides.
     /// </remarks>
+    [StructLayout(LayoutKind.Explicit)]
     public struct IndexEntry
     {
-        /// <summary>
-        /// The largest time value seen up to the position specified by this entry.
-        /// </summary>
-        public DateTime CreationTime;
-
-        /// <summary>
-        /// The largest originating time value seen up to the position specified by this entry.
-        /// </summary>
-        public DateTime OriginatingTime;
-
         /// <summary>
         /// The id of the extent this index entry refers to.
         /// A negative extentId indicates an entry in the large file for \psi stores.
         /// </summary>
+        [FieldOffset(0)]
         public int ExtentId;
 
         /// <summary>
         /// The position within the extent to which this index entry points.
         /// </summary>
+        [FieldOffset(4)]
         public int Position;
+
+        /// <summary>
+        /// The largest time value seen up to the position specified by this entry.
+        /// </summary>
+        [FieldOffset(8)]
+        public DateTime CreationTime;
+
+        /// <summary>
+        /// The largest originating time value seen up to the position specified by this entry.
+        /// </summary>
+        [FieldOffset(16)]
+        public DateTime OriginatingTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IndexEntry"/> struct.


### PR DESCRIPTION
Fixes #296 where auto struct layouts have changed in .NET 7