### PR TITLE
Various updates to PsiStudio, Audio and Sigma

### DIFF
--- a/Applications/Microsoft.Psi.MixedReality.Applications.UniversalWindows/StereoKitClientApp.cs
+++ b/Applications/Microsoft.Psi.MixedReality.Applications.UniversalWindows/StereoKitClientApp.cs
@@ -207,6 +207,7 @@ namespace Microsoft.Psi.MixedReality.Applications
                 state = State.StoppingPipeline;
                 Task.Run(() =>
                 {
+                    this.OnStoppingPipeline();
                     try
                     {
                         pipeline?.Dispose();
@@ -822,7 +823,7 @@ namespace Microsoft.Psi.MixedReality.Applications
         }
 
         /// <summary>
-        /// Populates the UI at the waiting to start point.
+        /// Virtual method that populates the UI at the waiting to start point.
         /// </summary>
         public virtual void OnWaitingForStart()
         {
@@ -871,6 +872,13 @@ namespace Microsoft.Psi.MixedReality.Applications
             {
                 this.selectedIgnoreComputeServerHeartbeat[this.SelectedConfiguration.Name] = false;
             }
+        }
+
+        /// <summary>
+        /// Virtual method that performs any relevant tasks just prior to stopping (disposing) the pipeline.
+        /// </summary>
+        public virtual void OnStoppingPipeline()
+        {
         }
 
         /// <summary>

--- a/Applications/Sigma/Sigma.UniversalWindows/Sigma.UniversalWindows.csproj
+++ b/Applications/Sigma/Sigma.UniversalWindows/Sigma.UniversalWindows.csproj
@@ -127,6 +127,10 @@
       <Project>{d55700d9-6050-44ac-abc0-ac1fbf9dfd3f}</Project>
       <Name>Microsoft.Psi.Spatial.Euclidean</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\Sources\Speech\Microsoft.Psi.Speech\Microsoft.Psi.Speech.csproj">
+      <Project>{3889F11A-B537-47F9-8819-146DB7E66B0C}</Project>
+      <Name>Microsoft.Psi.Speech</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Microsoft.Psi.MixedReality.Applications.UniversalWindows\Microsoft.Psi.MixedReality.Applications.UniversalWindows.csproj">
       <Project>{1afbbd50-ce3a-4792-be84-15e897d281dd}</Project>
       <Name>Microsoft.Psi.MixedReality.Applications.UniversalWindows</Name>

--- a/Applications/Sigma/Sigma.UniversalWindows/SigmaAppConfiguration.cs
+++ b/Applications/Sigma/Sigma.UniversalWindows/SigmaAppConfiguration.cs
@@ -65,6 +65,12 @@ namespace Sigma
         public int AudioReframeSizeMs { get; set; } = 100;
 
         /// <summary>
+        /// Gets or sets the voice to use for the speech synthesizer. For possible options see
+        /// https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support?tabs=tts#prebuilt-neural-voices.
+        /// </summary>
+        public string SpeechSynthesizerVoiceName { get; set; } = "en-US-JennyNeural";
+
+        /// <summary>
         /// Creates a Sigma user interface.
         /// </summary>
         /// <param name="pipeline">The pipeline to add the components to.</param>

--- a/Applications/Sigma/Sigma/BatchProcessingTasks/ExportDataTask.cs
+++ b/Applications/Sigma/Sigma/BatchProcessingTasks/ExportDataTask.cs
@@ -22,7 +22,7 @@ namespace Sigma
     /// Batch task for exporting Sigma data.
     /// </summary>
     [BatchProcessingTask(
-        "Sigma - Export Captured Data",
+        "Export Captured Data",
         Description = "This task exports the data collected by the Sigma app to a set of text files.")]
     public class ExportDataTask : BatchProcessingTask<ExportDataTaskConfiguration>
     {

--- a/Applications/Sigma/Sigma/BatchProcessingTasks/ExportNotesTask.cs
+++ b/Applications/Sigma/Sigma/BatchProcessingTasks/ExportNotesTask.cs
@@ -17,7 +17,7 @@ namespace Sigma
     /// Batch task for exporting Sigma data.
     /// </summary>
     [BatchProcessingTask(
-        "Sigma - Export User Notes",
+        "Export User Notes",
         Description = "This task exports notes taken by the user to a tab-delimited file.")]
     public class ExportNotesTask : BatchProcessingTask<ExportNotesTask.ExportNotesTaskConfiguration>
     {

--- a/Applications/Sigma/Sigma/BatchProcessingTasks/Object2DDetectionBasedObjectTrackerTask.cs
+++ b/Applications/Sigma/Sigma/BatchProcessingTasks/Object2DDetectionBasedObjectTrackerTask.cs
@@ -17,7 +17,7 @@ namespace Sigma
     /// Batch task that runs the object 2D detection based tracker.
     /// </summary>
     [BatchProcessingTask(
-        "Sigma - Run the object 2D detection based tracker",
+        "Run the object 2D detection based tracker",
         Description = "This task generates a new partition with results from object 2D detection based tracking.")]
     public class Object2DDetectionBasedObjectTrackerTask : BatchProcessingTask<Object2DDetectionBasedObjectTrackerTaskConfiguration>
     {

--- a/Applications/Sigma/Sigma/InteractionModels/Diamond/DiamondInteractionModel.cs
+++ b/Applications/Sigma/Sigma/InteractionModels/Diamond/DiamondInteractionModel.cs
@@ -142,11 +142,11 @@ namespace Sigma.Diamond
         {
             if (this.InteractionState.TryGetSelectedStepOfType<DoStep>(out var _) || this.InteractionState.TryGetSelectedStepOfType<GatherStep>(out var _))
             {
-                yield return DialogAction.ContinueWith<DiamondDialogStates.ExecuteStep>();
+                yield return DialogAction.ContinueWith<ExecuteStep>();
             }
             else if (this.InteractionState.TryGetSelectedStepOfType<ComplexStep>(out var _))
             {
-                yield return DialogAction.ContinueWith<DiamondDialogStates.ExecuteComplexStep>();
+                yield return DialogAction.ContinueWith<ExecuteComplexStep>();
             }
             else
             {

--- a/Sources/Audio/Microsoft.Psi.Audio/BatchProcessingTasks/ExportAudioToWavFileTask.cs
+++ b/Sources/Audio/Microsoft.Psi.Audio/BatchProcessingTasks/ExportAudioToWavFileTask.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.Psi.Audio
+{
+    using System.ComponentModel;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using Microsoft.Psi;
+    using Microsoft.Psi.Data;
+
+    /// <summary>
+    /// Batch task that exports audio streams to a wav file.
+    /// </summary>
+    [BatchProcessingTask(
+        "Export Audio to Wav File",
+        Description = "This task exports an audio stream to a wav file.")]
+    public class ExportAudioToWavFileTask : BatchProcessingTask<ExportAudioToWavFileTaskConfiguration>
+    {
+        /// <inheritdoc/>
+        public override void Run(Pipeline pipeline, SessionImporter sessionImporter, Exporter exporter, ExportAudioToWavFileTaskConfiguration configuration)
+        {
+            var audio = sessionImporter.OpenStream<AudioBuffer>(configuration.AudioStreamName);
+            var partition = sessionImporter.PartitionImporters.Values.First();
+            var wavFileWriter = new WaveFileWriter(pipeline, Path.Combine(partition.StorePath, configuration.WavOutputFilename));
+
+            var streamlinedAudio = audio.Streamline(configuration.AudioStreamlineMethod, configuration.MaxOffsetBeforeUnpleatedRealignmentMs);
+            if (exporter != null)
+            {
+                streamlinedAudio.Write(configuration.OutputAudioStreamName, exporter);
+            }
+
+            streamlinedAudio.PipeTo(wavFileWriter);
+        }
+    }
+
+    /// <summary>
+    /// Represents the configuration for the <see cref="ExportAudioToWavFileTask"/>.
+    /// </summary>
+#pragma warning disable SA1402 // File may only contain a single type
+    public class ExportAudioToWavFileTaskConfiguration : BatchProcessingTaskConfiguration
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+        private string audioStreamName = "Audio";
+        private string outputAudioStreamName = "Audio";
+        private string wavOutputFilename = "Audio.wav";
+        private AudioStreamlineMethod audioStreamlineMethod = AudioStreamlineMethod.Unpleat;
+        private double maxOffsetBeforeUnpleatedRealignmentMs = 20;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportAudioToWavFileTaskConfiguration"/> class.
+        /// </summary>
+        public ExportAudioToWavFileTaskConfiguration()
+            : base()
+        {
+            this.OutputStoreName = string.Empty;
+            this.OutputPartitionName = string.Empty;
+            this.DeliveryPolicySpec = DeliveryPolicySpec.Throttle;
+            this.ReplayAllRealTime = false;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the audio stream.
+        /// </summary>
+        [DataMember]
+        [DisplayName("Audio Stream Name")]
+        [Description("The name of the audio stream.")]
+        public string AudioStreamName
+        {
+            get => this.audioStreamName;
+            set { this.Set(nameof(this.AudioStreamName), ref this.audioStreamName, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the output audio stream.
+        /// </summary>
+        [DataMember]
+        [DisplayName("Output Audio Stream Name")]
+        [Description("The name of the output audio stream.")]
+        public string OutputAudioStreamName
+        {
+            get => this.outputAudioStreamName;
+            set { this.Set(nameof(this.OutputAudioStreamName), ref this.outputAudioStreamName, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of a wave output file.
+        /// </summary>
+        [DataMember]
+        [DisplayName("Wave Output Filename")]
+        [Description("The filename is relative to the partition folder.")]
+        public string WavOutputFilename
+        {
+            get => this.wavOutputFilename;
+            set { this.Set(nameof(this.WavOutputFilename), ref this.wavOutputFilename, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the method used to streamline the audio stream.
+        /// </summary>
+        [DataMember]
+        [DisplayName("Audio Streamline Method")]
+        [Description("The method used to streamline the audio stream.")]
+        public AudioStreamlineMethod AudioStreamlineMethod
+        {
+            get => this.audioStreamlineMethod;
+            set { this.Set(nameof(this.AudioStreamlineMethod), ref this.audioStreamlineMethod, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum offset before realignment in milliseconds.
+        /// </summary>
+        [DataMember]
+        [DisplayName("Max Offset Before Realignment (ms)")]
+        [Description("The maximum time offset between the unpleated stream and originating times before a realignment is enforced (in milliseconds).")]
+        public double MaxOffsetBeforeUnpleatedRealignmentMs
+        {
+            get => this.maxOffsetBeforeUnpleatedRealignmentMs;
+            set { this.Set(nameof(this.MaxOffsetBeforeUnpleatedRealignmentMs), ref this.maxOffsetBeforeUnpleatedRealignmentMs, value); }
+        }
+    }
+}

--- a/Sources/Audio/Microsoft.Psi.Audio/WaveFormat.cs
+++ b/Sources/Audio/Microsoft.Psi.Audio/WaveFormat.cs
@@ -130,18 +130,18 @@ namespace Microsoft.Psi.Audio
         /// Creates a new instance of the <see cref="WaveFormat"/> class.
         /// </summary>
         /// <param name="formatTag">The format tag.</param>
-        /// <param name="samplingRate">The sampling frequency.</param>
+        /// <param name="samplesPerSecond">The sampling frequency.</param>
         /// <param name="bitsPerSample">The number of bits per channel sample.</param>
         /// <param name="channels">The number of audio channels.</param>
         /// <param name="blockAlign">The block alignment.</param>
         /// <param name="avgBytesPerSecond">The average number of bytes per second.</param>
         /// <returns>The WaveFormat object.</returns>
-        public static WaveFormat Create(WaveFormatTag formatTag, int samplingRate, int bitsPerSample, int channels, int blockAlign, int avgBytesPerSecond)
+        public static WaveFormat Create(WaveFormatTag formatTag, int samplesPerSecond, int bitsPerSample, int channels, int blockAlign, int avgBytesPerSecond)
         {
             return new WaveFormat()
             {
                 FormatTag = formatTag,
-                SamplesPerSec = (uint)samplingRate,
+                SamplesPerSec = (uint)samplesPerSecond,
                 BitsPerSample = (ushort)bitsPerSample,
                 Channels = (ushort)channels,
                 BlockAlign = (ushort)blockAlign,

--- a/Sources/Data/Microsoft.Psi.Data/BatchProcessingTaskMetadata.cs
+++ b/Sources/Data/Microsoft.Psi.Data/BatchProcessingTaskMetadata.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Psi.Data
         public string ConfigurationsPath => this.batchProcessingTaskConfigurationsPath;
 
         /// <summary>
+        /// Gets the namespace for the batch processing task type.
+        /// </summary>
+        public string Namespace => this.batchProcessingTaskType.Namespace;
+
+        /// <summary>
         /// Gets or sets the name of the most recently used configuration.
         /// </summary>
         public string MostRecentlyUsedConfiguration { get; set; }

--- a/Sources/Data/Microsoft.Psi.Data/Session.cs
+++ b/Sources/Data/Microsoft.Psi.Data/Session.cs
@@ -323,7 +323,7 @@ namespace Microsoft.Psi.Data
                         // create and run the pipeline
                         using var pipeline = Pipeline.Create(enableDiagnostics: enableDiagnostics, deliveryPolicy: deliveryPolicy);
                         var importer = SessionImporter.Open(pipeline, this);
-                        var exporter = outputPartitionName != null ? PsiStore.Create(pipeline, outputStoreName, outputStorePath, createSubdirectory: false) : null;
+                        var exporter = string.IsNullOrEmpty(outputPartitionName) ? null : PsiStore.Create(pipeline, outputStoreName, outputStorePath, createSubdirectory: false);
 
                         computeDerived(pipeline, importer, exporter, parameter);
 
@@ -353,7 +353,7 @@ namespace Microsoft.Psi.Data
                 cancellationToken);
 
             // add the partition
-            if (outputPartitionName != null)
+            if (!string.IsNullOrEmpty(outputPartitionName))
             {
                 await this.AddPartitionFromPsiStoreAsync(
                     outputStoreName,

--- a/Sources/Integrations/CognitiveServices/Microsoft.Psi.CognitiveServices.Speech/SpeechSynthesizerConfiguration.cs
+++ b/Sources/Integrations/CognitiveServices/Microsoft.Psi.CognitiveServices.Speech/SpeechSynthesizerConfiguration.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Psi.CognitiveServices.Speech
 {
+    using System;
+    using Microsoft.Psi.Speech;
+
     /// <summary>
     /// Represents the configuration for the <see cref="SpeechSynthesizer"/> component.
     /// </summary>
@@ -19,8 +22,33 @@ namespace Microsoft.Psi.CognitiveServices.Speech
         public string Region { get; set; } = null;
 
         /// <summary>
+        /// Gets or sets the speech synthesis voice name.
+        /// </summary>
+        public string VoiceName { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the max size of the packets of audio to be posted (number of bytes).
         /// </summary>
         public int AudioPacketSize { get; set; } = 4096;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the audio buffers are streamed in real-time.
+        /// </summary>
+        public bool StreamAudioBuffersInRealTime { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the maximum real-time anticipation when streaming audio buffers in real-time.
+        /// </summary>
+        /// <remarks>
+        /// When configured to stream audio buffers in real-time, the speech synthesizer will send audio buffers
+        /// if the originating time of the audio buffer is within this time-span of the current time. This is to
+        /// ensure adequate time for the audio buffers to be processed and played out in real-time.
+        /// </remarks>
+        public TimeSpan MaxRealTimeAnticipationWhenStreamingAudioBuffersInRealTime { get; set; } = TimeSpan.FromMilliseconds(300);
+
+        /// <summary>
+        /// Gets or sets the cache to use for speech synthesis.
+        /// </summary>
+        public SpeechSynthesisCache Cache { get; set; } = null;
     }
 }

--- a/Sources/Runtime/Microsoft.Psi/Common/Intervals/IntInterval.cs
+++ b/Sources/Runtime/Microsoft.Psi/Common/Intervals/IntInterval.cs
@@ -14,18 +14,17 @@ namespace Microsoft.Psi
         /// <summary>
         /// Canonical infinite interval (unbounded on both ends).
         /// </summary>
-        public static readonly IntInterval Infinite =
-            new IntInterval(int.MinValue, false, false, int.MaxValue, false, false);
+        public static readonly IntInterval Infinite = new (int.MinValue, false, false, int.MaxValue, false, false);
 
         /// <summary>
         /// Canonical empty instance (bounded, non-inclusive, single point).
         /// </summary>
-        public static readonly IntInterval Empty = new IntInterval(0, false, true, 0, false, true);
+        public static readonly IntInterval Empty = new (0, false, true, 0, false, true);
 
         /// <summary>
         /// Zero interval (unbounded but inclusive, zero value).
         /// </summary>
-        public static readonly IntInterval Zero = new IntInterval(0, true, true, 0, true, true);
+        public static readonly IntInterval Zero = new (0, true, true, 0, true, true);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IntInterval"/> class.
@@ -79,53 +78,44 @@ namespace Microsoft.Psi
         /// <summary>
         /// Gets the point minimum value.
         /// </summary>
-        protected override int PointMinValue
-        {
-            get { return int.MinValue; }
-        }
+        protected override int PointMinValue => int.MinValue;
 
         /// <summary>
         /// Gets the point maximum value.
         /// </summary>
-        protected override int PointMaxValue
-        {
-            get { return int.MaxValue; }
-        }
+        protected override int PointMaxValue => int.MaxValue;
 
         /// <summary>
         /// Gets the span zero value.
         /// </summary>
-        protected override int SpanZeroValue
-        {
-            get { return 0; }
-        }
+        protected override int SpanZeroValue => 0;
 
         /// <summary>
         /// Gets the span minimum value.
         /// </summary>
-        protected override int SpanMinValue
-        {
-            get { return int.MinValue; }
-        }
+        protected override int SpanMinValue => int.MinValue;
 
         /// <summary>
         /// Gets the span maximum value.
         /// </summary>
-        protected override int SpanMaxValue
-        {
-            get { return int.MaxValue; }
-        }
+        protected override int SpanMaxValue => int.MaxValue;
 
         /// <summary>
-        /// Determine coverage from minimum left to maximum right.
+        /// Merges a specified set of int intervals into a set of non-overlapping int intervals that cover the specified intervals.
         /// </summary>
-        /// <param name="intervals">Sequence of intervals.</param>
-        /// <remarks>Returns negative interval from max to min point when sequence is empty.</remarks>
+        /// <param name="intervals">A set of intervals to cover.</param>
+        /// <returns>Set of non-overlapping intervals that cover the given intervals.</returns>
+        public static IEnumerable<IntInterval> Merge(IEnumerable<IntInterval> intervals)
+            => Merge(intervals, (left, right) => new IntInterval(left, right));
+
+        /// <summary>
+        /// Determine coverage from minimum left to maximum right for a set of given intervals.
+        /// </summary>
+        /// <param name="intervals">The set of intervals.</param>
+        /// <remarks>Returns empty interval when sequence is empty or contains only empty intervals.</remarks>
         /// <returns>Interval from minimum left to maximum right value.</returns>
         public static IntInterval Coverage(IEnumerable<IntInterval> intervals)
-        {
-            return Coverage(intervals, (left, right) => new IntInterval(left, right), IntInterval.Empty);
-        }
+            => Coverage(intervals, (left, right) => new IntInterval(left, right), IntInterval.Empty);
 
         /// <summary>
         /// Constructor helper for left-bound instances.
@@ -134,9 +124,7 @@ namespace Microsoft.Psi
         /// <param name="inclusive">Whether left point is inclusive.</param>
         /// <returns>A left-bound instance of the <see cref="IntInterval"/> class.</returns>
         public static IntInterval LeftBounded(int left, bool inclusive)
-        {
-            return new IntInterval(left, inclusive, true, int.MaxValue, false, false);
-        }
+            => new (left, inclusive, true, int.MaxValue, false, false);
 
         /// <summary>
         /// Constructor helper for left-bound instances.
@@ -144,10 +132,7 @@ namespace Microsoft.Psi
         /// <remarks>Defaults to inclusive.</remarks>
         /// <param name="left">Left bound point.</param>
         /// <returns>A left-bound instance of the <see cref="IntInterval"/> class.</returns>
-        public static IntInterval LeftBounded(int left)
-        {
-            return LeftBounded(left, true);
-        }
+        public static IntInterval LeftBounded(int left) => LeftBounded(left, true);
 
         /// <summary>
         /// Constructor helper for right-bound instances.
@@ -156,9 +141,7 @@ namespace Microsoft.Psi
         /// <param name="inclusive">Whether right point is inclusive.</param>
         /// <returns>A right-bound instance of the <see cref="IntInterval"/> class.</returns>
         public static IntInterval RightBounded(int right, bool inclusive)
-        {
-            return new IntInterval(int.MinValue, false, false, right, inclusive, true);
-        }
+            => new (int.MinValue, false, false, right, inclusive, true);
 
         /// <summary>
         /// Constructor helper for right-bound instances.
@@ -166,10 +149,7 @@ namespace Microsoft.Psi
         /// <remarks>Defaults to inclusive.</remarks>
         /// <param name="right">Right bound point.</param>
         /// <returns>A right-bound instance of the <see cref="IntInterval"/> class.</returns>
-        public static IntInterval RightBounded(int right)
-        {
-            return RightBounded(right, true);
-        }
+        public static IntInterval RightBounded(int right) => RightBounded(right, true);
 
         /// <summary>
         /// Translate by a span distance.
@@ -178,9 +158,7 @@ namespace Microsoft.Psi
         /// <param name="span">Span by which to translate.</param>
         /// <returns>Translated interval.</returns>
         public override IntInterval Translate(int span)
-        {
-            return this.Translate(span, (lp, li, lb, rp, ri, rb) => new IntInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Translate(span, (lp, li, lb, rp, ri, rb) => new IntInterval(lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale endpoints by span distances.
@@ -189,9 +167,7 @@ namespace Microsoft.Psi
         /// <param name="right">Span by which to scale right.</param>
         /// <returns>Scaled interval.</returns>
         public override IntInterval Scale(int left, int right)
-        {
-            return this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new IntInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new IntInterval(lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale endpoints by factors.
@@ -200,9 +176,7 @@ namespace Microsoft.Psi
         /// <param name="right">Factor by which to scale right.</param>
         /// <returns>Scaled interval.</returns>
         public override IntInterval Scale(float left, float right)
-        {
-            return this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new IntInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new IntInterval(lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale a span by a given factor.
@@ -210,20 +184,14 @@ namespace Microsoft.Psi
         /// <param name="span">Span value.</param>
         /// <param name="factor">Factor by which to scale.</param>
         /// <returns>Scaled span.</returns>
-        protected override int ScaleSpan(int span, double factor)
-        {
-            return (int)Math.Round(span * factor);
-        }
+        protected override int ScaleSpan(int span, double factor) => (int)Math.Round(span * factor);
 
         /// <summary>
         /// Negate span.
         /// </summary>
         /// <param name="span">Span to be negated.</param>
         /// <returns>Negated span..</returns>
-        protected override int NegateSpan(int span)
-        {
-            return -span;
-        }
+        protected override int NegateSpan(int span) => -span;
 
         /// <summary>
         /// Translate point by given span.
@@ -231,10 +199,7 @@ namespace Microsoft.Psi
         /// <param name="point">Point value.</param>
         /// <param name="span">Span by which to translate.</param>
         /// <returns>Translated point.</returns>
-        protected override int TranslatePoint(int point, int span)
-        {
-            return point + span;
-        }
+        protected override int TranslatePoint(int point, int span) => point + span;
 
         /// <summary>
         /// Determine span between two given points.
@@ -242,10 +207,7 @@ namespace Microsoft.Psi
         /// <param name="x">First point.</param>
         /// <param name="y">Second point.</param>
         /// <returns>Span between points.</returns>
-        protected override int Difference(int x, int y)
-        {
-            return x - y;
-        }
+        protected override int Difference(int x, int y) => x - y;
 
         /// <summary>
         /// Compare points.
@@ -253,9 +215,6 @@ namespace Microsoft.Psi
         /// <param name="a">First point.</param>
         /// <param name="b">Second point.</param>
         /// <returns>Less (-1), greater (+1) or equal (0).</returns>
-        protected override int ComparePoints(int a, int b)
-        {
-            return a.CompareTo(b);
-        }
+        protected override int ComparePoints(int a, int b) => a.CompareTo(b);
     }
 }

--- a/Sources/Runtime/Microsoft.Psi/Common/Intervals/RealInterval.cs
+++ b/Sources/Runtime/Microsoft.Psi/Common/Intervals/RealInterval.cs
@@ -14,18 +14,17 @@ namespace Microsoft.Psi
         /// <summary>
         /// Canonical infinite interval (unbounded on both ends).
         /// </summary>
-        public static readonly RealInterval Infinite =
-            new RealInterval(double.MinValue, false, false, double.MaxValue, false, false);
+        public static readonly RealInterval Infinite = new (double.MinValue, false, false, double.MaxValue, false, false);
 
         /// <summary>
         /// Canonical empty instance (bounded, non-inclusive, single point).
         /// </summary>
-        public static readonly RealInterval Empty = new RealInterval(0, false, true, 0, false, true);
+        public static readonly RealInterval Empty = new (0, false, true, 0, false, true);
 
         /// <summary>
         /// Zero interval (unbounded but inclusive, zero value).
         /// </summary>
-        public static readonly RealInterval Zero = new RealInterval(0, true, true, 0, true, true);
+        public static readonly RealInterval Zero = new (0, true, true, 0, true, true);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RealInterval"/> class.
@@ -79,53 +78,44 @@ namespace Microsoft.Psi
         /// <summary>
         /// Gets the point minimum value.
         /// </summary>
-        protected override double PointMinValue
-        {
-            get { return double.MinValue; }
-        }
+        protected override double PointMinValue => double.MinValue;
 
         /// <summary>
         /// Gets the point maximum value.
         /// </summary>
-        protected override double PointMaxValue
-        {
-            get { return double.MaxValue; }
-        }
+        protected override double PointMaxValue => double.MaxValue;
 
         /// <summary>
         /// Gets the span zero value.
         /// </summary>
-        protected override double SpanZeroValue
-        {
-            get { return 0.0; }
-        }
+        protected override double SpanZeroValue => 0.0;
 
         /// <summary>
         /// Gets the span minimum value.
         /// </summary>
-        protected override double SpanMinValue
-        {
-            get { return double.MinValue; }
-        }
+        protected override double SpanMinValue => double.MinValue;
 
         /// <summary>
         /// Gets the span maximum value.
         /// </summary>
-        protected override double SpanMaxValue
-        {
-            get { return double.MaxValue; }
-        }
+        protected override double SpanMaxValue => double.MaxValue;
 
         /// <summary>
-        /// Determine coverage from minimum left to maximum right.
+        /// Merges a specified set of real intervals into a set of non-overlapping real intervals that cover the specified intervals.
         /// </summary>
-        /// <param name="intervals">Sequence of intervals.</param>
-        /// <remarks>Returns negative interval from max to min point when sequence is empty.</remarks>
+        /// <param name="intervals">A set of intervals to cover.</param>
+        /// <returns>Set of non-overlapping intervals that cover the given intervals.</returns>
+        public static IEnumerable<RealInterval> Merge(IEnumerable<RealInterval> intervals)
+            => Merge(intervals, (left, right) => new (left, right));
+
+        /// <summary>
+        /// Determine coverage from minimum left to maximum right for a set of given intervals.
+        /// </summary>
+        /// <param name="intervals">The set of intervals.</param>
+        /// <remarks>Returns empty interval when sequence is empty or contains only empty intervals.</remarks>
         /// <returns>Interval from minimum left to maximum right value.</returns>
         public static RealInterval Coverage(IEnumerable<RealInterval> intervals)
-        {
-            return Coverage(intervals, (left, right) => new RealInterval(left, right), RealInterval.Empty);
-        }
+            => Coverage(intervals, (left, right) => new RealInterval(left, right), RealInterval.Empty);
 
         /// <summary>
         /// Constructor helper for left-bound instances.
@@ -134,9 +124,7 @@ namespace Microsoft.Psi
         /// <param name="inclusive">Whether left point is inclusive.</param>
         /// <returns>A left-bound instance of the <see cref="RealInterval"/> class.</returns>
         public static RealInterval LeftBounded(double left, bool inclusive)
-        {
-            return new RealInterval(left, inclusive, true, double.MaxValue, false, false);
-        }
+            => new (left, inclusive, true, double.MaxValue, false, false);
 
         /// <summary>
         /// Constructor helper for left-bound instances.
@@ -144,10 +132,7 @@ namespace Microsoft.Psi
         /// <remarks>Defaults to inclusive.</remarks>
         /// <param name="left">Left bound point.</param>
         /// <returns>A left-bound instance of the <see cref="RealInterval"/> class.</returns>
-        public static RealInterval LeftBounded(double left)
-        {
-            return LeftBounded(left, true);
-        }
+        public static RealInterval LeftBounded(double left) => LeftBounded(left, true);
 
         /// <summary>
         /// Constructor helper for right-bound instances.
@@ -156,9 +141,7 @@ namespace Microsoft.Psi
         /// <param name="inclusive">Whether right point is inclusive.</param>
         /// <returns>A right-bound instance of the <see cref="RealInterval"/> class.</returns>
         public static RealInterval RightBounded(double right, bool inclusive)
-        {
-            return new RealInterval(double.MinValue, false, false, right, inclusive, true);
-        }
+            => new (double.MinValue, false, false, right, inclusive, true);
 
         /// <summary>
         /// Constructor helper for right-bound instances.
@@ -166,10 +149,7 @@ namespace Microsoft.Psi
         /// <remarks>Defaults to inclusive.</remarks>
         /// <param name="right">Right bound point.</param>
         /// <returns>A right-bound instance of the <see cref="RealInterval"/> class.</returns>
-        public static RealInterval RightBounded(double right)
-        {
-            return RightBounded(right, true);
-        }
+        public static RealInterval RightBounded(double right) => RightBounded(right, true);
 
         /// <summary>
         /// Translate by a span distance.
@@ -178,9 +158,7 @@ namespace Microsoft.Psi
         /// <param name="span">Span by which to translate.</param>
         /// <returns>Translated interval.</returns>
         public override RealInterval Translate(double span)
-        {
-            return this.Translate(span, (lp, li, lb, rp, ri, rb) => new RealInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Translate(span, (lp, li, lb, rp, ri, rb) => new (lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale endpoints by span distances.
@@ -189,9 +167,7 @@ namespace Microsoft.Psi
         /// <param name="right">Span by which to scale right.</param>
         /// <returns>Scaled interval.</returns>
         public override RealInterval Scale(double left, double right)
-        {
-            return this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new RealInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new (lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale endpoints by factors.
@@ -200,9 +176,7 @@ namespace Microsoft.Psi
         /// <param name="right">Factor by which to scale right.</param>
         /// <returns>Scaled interval.</returns>
         public override RealInterval Scale(float left, float right)
-        {
-            return this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new RealInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new (lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale a span by a given factor.
@@ -210,20 +184,14 @@ namespace Microsoft.Psi
         /// <param name="span">Span value.</param>
         /// <param name="factor">Factor by which to scale.</param>
         /// <returns>Scaled span.</returns>
-        protected override double ScaleSpan(double span, double factor)
-        {
-            return Math.Round(span * factor);
-        }
+        protected override double ScaleSpan(double span, double factor) => Math.Round(span * factor);
 
         /// <summary>
         /// Negate span.
         /// </summary>
         /// <param name="span">Span to be negated.</param>
         /// <returns>Negated span.</returns>
-        protected override double NegateSpan(double span)
-        {
-            return -span;
-        }
+        protected override double NegateSpan(double span) => -span;
 
         /// <summary>
         /// Translate point by given span.
@@ -231,10 +199,7 @@ namespace Microsoft.Psi
         /// <param name="point">Point value.</param>
         /// <param name="span">Span by which to translate.</param>
         /// <returns>Translated point.</returns>
-        protected override double TranslatePoint(double point, double span)
-        {
-            return point + span;
-        }
+        protected override double TranslatePoint(double point, double span) => point + span;
 
         /// <summary>
         /// Determine span between two given points.
@@ -242,10 +207,7 @@ namespace Microsoft.Psi
         /// <param name="x">First point.</param>
         /// <param name="y">Second point.</param>
         /// <returns>Span between points.</returns>
-        protected override double Difference(double x, double y)
-        {
-            return x - y;
-        }
+        protected override double Difference(double x, double y) => x - y;
 
         /// <summary>
         /// Compare points.
@@ -253,9 +215,6 @@ namespace Microsoft.Psi
         /// <param name="a">First point.</param>
         /// <param name="b">Second point.</param>
         /// <returns>Less (-1), greater (+1) or equal (0).</returns>
-        protected override int ComparePoints(double a, double b)
-        {
-            return a.CompareTo(b);
-        }
+        protected override int ComparePoints(double a, double b) => a.CompareTo(b);
     }
 }

--- a/Sources/Runtime/Microsoft.Psi/Common/Intervals/RelativeTimeInterval.cs
+++ b/Sources/Runtime/Microsoft.Psi/Common/Intervals/RelativeTimeInterval.cs
@@ -146,8 +146,7 @@ namespace Microsoft.Psi
         /// <param name="origin">Origin time point.</param>
         /// <param name="relative">Relative endpoints.</param>
         /// <returns>Translated interval.</returns>
-        public static TimeInterval operator +(DateTime origin, RelativeTimeInterval relative)
-            => new (origin, relative);
+        public static TimeInterval operator +(DateTime origin, RelativeTimeInterval relative) => new (origin, relative);
 
         /// <summary>
         /// Returns a relative time interval describing the past. The returned interval includes the present moment.
@@ -180,10 +179,18 @@ namespace Microsoft.Psi
             => new (TimeSpan.Zero, true, true, duration, inclusive, true);
 
         /// <summary>
-        /// Determine coverage from minimum left to maximum right.
+        /// Merges a specified set of relative time intervals into a set of non-overlapping relative time intervals that cover the specified intervals.
         /// </summary>
-        /// <param name="intervals">Sequence of intervals.</param>
-        /// <remarks>Returns negative interval from max to min point when sequence is empty.</remarks>
+        /// <param name="intervals">A set of relative time intervals to cover.</param>
+        /// <returns>Set of non-overlapping time intervals that cover the given time intervals.</returns>
+        public static IEnumerable<RelativeTimeInterval> Merge(IEnumerable<RelativeTimeInterval> intervals)
+            => Merge(intervals, (left, right) => new RelativeTimeInterval(left, right));
+
+        /// <summary>
+        /// Determine coverage from minimum left to maximum right for a set of given intervals.
+        /// </summary>
+        /// <param name="intervals">The set of intervals.</param>
+        /// <remarks>Returns empty interval when sequence is empty or contains only empty intervals.</remarks>
         /// <returns>Interval from minimum left to maximum right value.</returns>
         public static RelativeTimeInterval Coverage(IEnumerable<RelativeTimeInterval> intervals)
             => Coverage(intervals, (left, right) => new RelativeTimeInterval(left, right), RelativeTimeInterval.Empty);
@@ -250,8 +257,7 @@ namespace Microsoft.Psi
             => this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new RelativeTimeInterval(lp, li, lb, rp, ri, rb));
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
-            => (obj is RelativeTimeInterval other) && this.Equals(other);
+        public override bool Equals(object obj) => (obj is RelativeTimeInterval other) && this.Equals(other);
 
         /// <inheritdoc/>
         public bool Equals(RelativeTimeInterval other)
@@ -283,8 +289,7 @@ namespace Microsoft.Psi
         /// <param name="span">Span value.</param>
         /// <param name="factor">Factor by which to scale.</param>
         /// <returns>Scaled span.</returns>
-        protected override TimeSpan ScaleSpan(TimeSpan span, double factor)
-            => new ((long)Math.Round(span.Ticks * factor));
+        protected override TimeSpan ScaleSpan(TimeSpan span, double factor) => new ((long)Math.Round(span.Ticks * factor));
 
         /// <summary>
         /// Negate span.

--- a/Sources/Runtime/Microsoft.Psi/Common/Intervals/TimeInterval.cs
+++ b/Sources/Runtime/Microsoft.Psi/Common/Intervals/TimeInterval.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Psi
         /// Canonical infinite interval (unbounded on both ends).
         /// </summary>
         public static readonly TimeInterval Infinite =
-            new TimeInterval(DateTime.MinValue, false, false, DateTime.MaxValue, false, false);
+            new (DateTime.MinValue, false, false, DateTime.MaxValue, false, false);
 
         /// <summary>
         /// Canonical empty instance (bounded, non-inclusive, single point).
         /// </summary>
         public static readonly TimeInterval Empty =
-            new TimeInterval(DateTime.MinValue, false, true, DateTime.MinValue, false, true);
+            new (DateTime.MinValue, false, true, DateTime.MinValue, false, true);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeInterval"/> class.
@@ -87,53 +87,44 @@ namespace Microsoft.Psi
         /// <summary>
         /// Gets the point minimum value.
         /// </summary>
-        protected override DateTime PointMinValue
-        {
-            get { return DateTime.MinValue; }
-        }
+        protected override DateTime PointMinValue => DateTime.MinValue;
 
         /// <summary>
         /// Gets the point maximum value.
         /// </summary>
-        protected override DateTime PointMaxValue
-        {
-            get { return DateTime.MaxValue; }
-        }
+        protected override DateTime PointMaxValue => DateTime.MaxValue;
 
         /// <summary>
         /// Gets the span zero value.
         /// </summary>
-        protected override TimeSpan SpanZeroValue
-        {
-            get { return TimeSpan.Zero; }
-        }
+        protected override TimeSpan SpanZeroValue => TimeSpan.Zero;
 
         /// <summary>
         /// Gets the span minimum value.
         /// </summary>
-        protected override TimeSpan SpanMinValue
-        {
-            get { return TimeSpan.MinValue; }
-        }
+        protected override TimeSpan SpanMinValue => TimeSpan.MinValue;
 
         /// <summary>
         /// Gets the span maximum value.
         /// </summary>
-        protected override TimeSpan SpanMaxValue
-        {
-            get { return TimeSpan.MaxValue; }
-        }
+        protected override TimeSpan SpanMaxValue => TimeSpan.MaxValue;
 
         /// <summary>
-        /// Determine coverage from minimum left to maximum right.
+        /// Merges a specified set of time intervals into a set of non-overlapping time intervals that cover the specified intervals.
         /// </summary>
-        /// <param name="intervals">Sequence of intervals.</param>
-        /// <remarks>Returns negative interval from max to min point when sequence is empty.</remarks>
+        /// <param name="intervals">A set of time intervals to cover.</param>
+        /// <returns>Set of non-overlapping time intervals that cover the given time intervals.</returns>
+        public static IEnumerable<TimeInterval> Merge(IEnumerable<TimeInterval> intervals)
+            => Merge(intervals, (left, right) => new TimeInterval(left, right));
+
+        /// <summary>
+        /// Determine coverage from minimum left to maximum right for a set of given intervals.
+        /// </summary>
+        /// <param name="intervals">The set of intervals.</param>
+        /// <remarks>Returns empty interval when sequence is empty or contains only empty intervals.</remarks>
         /// <returns>Interval from minimum left to maximum right value.</returns>
         public static TimeInterval Coverage(IEnumerable<TimeInterval> intervals)
-        {
-            return Coverage(intervals, (left, right) => new TimeInterval(left, right), TimeInterval.Empty);
-        }
+            => Coverage(intervals, (left, right) => new TimeInterval(left, right), TimeInterval.Empty);
 
         /// <summary>
         /// Determine intersection of a specified set of intervals.
@@ -142,9 +133,7 @@ namespace Microsoft.Psi
         /// <remarks>Returns empty when sequence is empty.</remarks>
         /// <returns>Intersection of the specified set of intervals.</returns>
         public static TimeInterval Intersection(IEnumerable<TimeInterval> intervals)
-        {
-            return Intersection(intervals, (left, right) => new TimeInterval(left, right), TimeInterval.Empty);
-        }
+            => Intersection(intervals, (left, right) => new TimeInterval(left, right), TimeInterval.Empty);
 
         /// <summary>
         /// Constructor helper for left-bound instances.
@@ -153,9 +142,7 @@ namespace Microsoft.Psi
         /// <param name="inclusive">Whether left point is inclusive.</param>
         /// <returns>A left-bound instance of the <see cref="TimeInterval"/> class.</returns>
         public static TimeInterval LeftBounded(DateTime left, bool inclusive)
-        {
-            return new TimeInterval(left, inclusive, true, DateTime.MaxValue, false, false);
-        }
+            => new (left, inclusive, true, DateTime.MaxValue, false, false);
 
         /// <summary>
         /// Constructor helper for left-bound instances.
@@ -163,10 +150,7 @@ namespace Microsoft.Psi
         /// <remarks>Defaults to inclusive.</remarks>
         /// <param name="left">Left bound point.</param>
         /// <returns>A left-bound instance of the <see cref="TimeInterval"/> class.</returns>
-        public static TimeInterval LeftBounded(DateTime left)
-        {
-            return LeftBounded(left, true);
-        }
+        public static TimeInterval LeftBounded(DateTime left) => LeftBounded(left, true);
 
         /// <summary>
         /// Constructor helper for right-bound instances.
@@ -175,9 +159,7 @@ namespace Microsoft.Psi
         /// <param name="inclusive">Whether right point is inclusive.</param>
         /// <returns>A right-bound instance of the <see cref="TimeInterval"/> class.</returns>
         public static TimeInterval RightBounded(DateTime right, bool inclusive)
-        {
-            return new TimeInterval(DateTime.MinValue, false, false, right, inclusive, true);
-        }
+            => new (DateTime.MinValue, false, false, right, inclusive, true);
 
         /// <summary>
         /// Constructor helper for right-bound instances.
@@ -185,10 +167,7 @@ namespace Microsoft.Psi
         /// <remarks>Defaults to inclusive.</remarks>
         /// <param name="right">Right bound point.</param>
         /// <returns>A right-bound instance of the <see cref="TimeInterval"/> class.</returns>
-        public static TimeInterval RightBounded(DateTime right)
-        {
-            return RightBounded(right, true);
-        }
+        public static TimeInterval RightBounded(DateTime right) => RightBounded(right, true);
 
         /// <summary>
         /// Intersects with a specified time interval.
@@ -205,9 +184,7 @@ namespace Microsoft.Psi
         /// <param name="span">Span by which to translate.</param>
         /// <returns>Translated interval.</returns>
         public override TimeInterval Translate(TimeSpan span)
-        {
-            return this.Translate(span, (lp, li, lb, rp, ri, rb) => new TimeInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Translate(span, (lp, li, lb, rp, ri, rb) => new TimeInterval(lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale endpoints by span distances.
@@ -216,9 +193,7 @@ namespace Microsoft.Psi
         /// <param name="right">Span by which to scale right.</param>
         /// <returns>Scaled interval.</returns>
         public override TimeInterval Scale(TimeSpan left, TimeSpan right)
-        {
-            return this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new TimeInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new TimeInterval(lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale endpoints by factors.
@@ -227,9 +202,7 @@ namespace Microsoft.Psi
         /// <param name="right">Factor by which to scale right.</param>
         /// <returns>Scaled interval.</returns>
         public override TimeInterval Scale(float left, float right)
-        {
-            return this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new TimeInterval(lp, li, lb, rp, ri, rb));
-        }
+            => this.Scale(left, right, (lp, li, lb, rp, ri, rb) => new TimeInterval(lp, li, lb, rp, ri, rb));
 
         /// <summary>
         /// Scale a span by a given factor.
@@ -238,19 +211,14 @@ namespace Microsoft.Psi
         /// <param name="factor">Factor by which to scale.</param>
         /// <returns>Scaled span.</returns>
         protected override TimeSpan ScaleSpan(TimeSpan span, double factor)
-        {
-            return TimeSpan.FromTicks((long)Math.Round(span.Ticks * factor));
-        }
+            => TimeSpan.FromTicks((long)Math.Round(span.Ticks * factor));
 
         /// <summary>
         /// Negate span.
         /// </summary>
         /// <param name="span">Span to be negated.</param>
         /// <returns>Negated span.</returns>
-        protected override TimeSpan NegateSpan(TimeSpan span)
-        {
-            return span.Negate();
-        }
+        protected override TimeSpan NegateSpan(TimeSpan span) => span.Negate();
 
         /// <summary>
         /// Translate point by given span.
@@ -258,10 +226,7 @@ namespace Microsoft.Psi
         /// <param name="point">Point value.</param>
         /// <param name="span">Span by which to translate.</param>
         /// <returns>Translated point.</returns>
-        protected override DateTime TranslatePoint(DateTime point, TimeSpan span)
-        {
-            return point + span;
-        }
+        protected override DateTime TranslatePoint(DateTime point, TimeSpan span) => point + span;
 
         /// <summary>
         /// Determine span between two given points.
@@ -269,10 +234,7 @@ namespace Microsoft.Psi
         /// <param name="x">First point.</param>
         /// <param name="y">Second point.</param>
         /// <returns>Span between points.</returns>
-        protected override TimeSpan Difference(DateTime x, DateTime y)
-        {
-            return x - y;
-        }
+        protected override TimeSpan Difference(DateTime x, DateTime y) => x - y;
 
         /// <summary>
         /// Compare points.
@@ -280,9 +242,6 @@ namespace Microsoft.Psi
         /// <param name="a">First point.</param>
         /// <param name="b">Second point.</param>
         /// <returns>Less (-1), greater (+1) or equal (0).</returns>
-        protected override int ComparePoints(DateTime a, DateTime b)
-        {
-            return a.CompareTo(b);
-        }
+        protected override int ComparePoints(DateTime a, DateTime b) => a.CompareTo(b);
     }
 }

--- a/Sources/Speech/Microsoft.Psi.Speech/SpeechSynthesisCache.cs
+++ b/Sources/Speech/Microsoft.Psi.Speech/SpeechSynthesisCache.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.Psi.Speech
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Psi.Audio;
+
+    /// <summary>
+    /// Implements a cache for speech synthesis content, mapping strings to audio buffers and corresponding text offsets.
+    /// </summary>
+    public class SpeechSynthesisCache
+    {
+        private readonly Dictionary<string, (AudioBuffer Data, List<(string Text, ulong Offset)> TextMapping)> cache = new ();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpeechSynthesisCache"/> class.
+        /// </summary>
+        /// <param name="speechSynthesisVoiceName">The name of the speech synthesis voice.</param>
+        public SpeechSynthesisCache(string speechSynthesisVoiceName)
+        {
+            this.SpeechSynthesisVoiceName = speechSynthesisVoiceName;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpeechSynthesisCache"/> class.
+        /// </summary>
+        /// <param name="stream">An optional stream from which to initialize the cache.</param>
+        public SpeechSynthesisCache(Stream stream = default)
+        {
+            if (stream != default)
+            {
+                this.Read(stream);
+            }
+        }
+
+        /// <summary>
+        /// Gets the speech synthesis voice name.
+        /// </summary>
+        public string SpeechSynthesisVoiceName { get; private set; }
+
+        /// <summary>
+        /// Reads the contents of the cache from a specified stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the cache.</param>
+        public void Read(Stream stream)
+        {
+            using var reader = new BinaryReader(stream);
+            this.SpeechSynthesisVoiceName = reader.ReadString();
+            var count = reader.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                // Read the key (text)
+                var text = reader.ReadString();
+
+                // Read the audio buffer
+                var data = reader.ReadBytes(reader.ReadInt32());
+                var waveFormat = WaveFormat.FromStream(stream, reader.ReadInt32());
+                var audioBuffer = new AudioBuffer(data, waveFormat);
+
+                // Read the text mapping
+                var textMapping = new List<(string Text, ulong Offset)>();
+                var textMappingCount = reader.ReadInt32();
+                for (int j = 0; j < textMappingCount; j++)
+                {
+                    var textMappingText = reader.ReadString();
+                    var textMappingOffset = reader.ReadUInt64();
+                    textMapping.Add((textMappingText, textMappingOffset));
+                }
+
+                // Add it to the cache
+                this.cache.Add(text, (audioBuffer, textMapping));
+            }
+        }
+
+        /// <summary>
+        /// Writes the cache to a file stream.
+        /// </summary>
+        /// <param name="stream">The stream to which to write the cache.</param>
+        public void Write(Stream stream)
+        {
+            using var writer = new BinaryWriter(stream);
+            writer.Write(this.SpeechSynthesisVoiceName);
+            writer.Write(this.cache.Count);
+            foreach (var entry in this.cache)
+            {
+                // Write the key (text)
+                writer.Write(entry.Key);
+
+                // Write the audio buffer
+                var audioBuffer = entry.Value.Data;
+                writer.Write(audioBuffer.Data.Length);
+                writer.Write(audioBuffer.Data);
+                writer.Write(WaveFormat.Size + audioBuffer.Format.ExtraSize);
+                audioBuffer.Format.WriteTo(writer);
+
+                // Write the text mapping
+                writer.Write(entry.Value.TextMapping.Count);
+                foreach (var (text, offset) in entry.Value.TextMapping)
+                {
+                    writer.Write(text);
+                    writer.Write(offset);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds a new entry to the cache.
+        /// </summary>
+        /// <param name="text">The text to add to the cache.</param>
+        /// <param name="audioBuffer">The corresponding audio buffer for the specified text.</param>
+        /// <param name="textMapping">A mapping of the text to the audio buffer.</param>
+        public void Add(string text, AudioBuffer audioBuffer, List<(string Text, ulong Offset)> textMapping)
+            => this.cache[text] = (audioBuffer, textMapping);
+
+        /// <summary>
+        /// Tries to get the audio buffer for the specified text.
+        /// </summary>
+        /// <param name="text">The text to look up in the cache.</param>
+        /// <param name="audioBuffer">The audio buffer for the specified text.</param>
+        /// <param name="textMapping">A mapping of the text to the audio buffer.</param>
+        /// <returns>True if the text is found in the cache, false otherwise.</returns>
+        public bool TryGetValue(string text, out AudioBuffer audioBuffer, out List<(string Text, ulong Offset)> textMapping)
+        {
+            if (this.cache.TryGetValue(text, out var tuple))
+            {
+                audioBuffer = tuple.Data;
+                textMapping = tuple.TextMapping;
+                return true;
+            }
+            else
+            {
+                audioBuffer = default;
+                textMapping = default;
+                return false;
+            }
+        }
+    }
+}

--- a/Sources/Tools/PsiStudio/Microsoft.Psi.PsiStudio/MainWindow.xaml
+++ b/Sources/Tools/PsiStudio/Microsoft.Psi.PsiStudio/MainWindow.xaml
@@ -210,7 +210,7 @@
                         </Style>
                     </Button.Style>
                 </Button>
-                <ToggleButton Command="{Binding TogglePlayRepeatCommand}" Margin="1" ToolTip="Repeat playback" AutomationProperties.Name="RepeatPlaybackToggleButton">
+                <ToggleButton IsChecked="{Binding VisualizationContainer.Navigator.RepeatPlayback, Mode=TwoWay}" Margin="1" ToolTip="Repeat playback" AutomationProperties.Name="RepeatPlaybackToggleButton">
                     <Image Source="{Binding ., Converter={StaticResource IconUriConverter}, ConverterParameter=play-repeat.png}"/>
                 </ToggleButton>
                 <Button Command="{Binding MoveCursorToSelectionEndCommand}" Margin="1" ToolTip="Move cursor to the end of the selection" AutomationProperties.Name="MoveCursorToEndOfSelectionButton">

--- a/Sources/Tools/PsiStudio/Microsoft.Psi.PsiStudio/MainWindowViewModel.cs
+++ b/Sources/Tools/PsiStudio/Microsoft.Psi.PsiStudio/MainWindowViewModel.cs
@@ -130,7 +130,6 @@ namespace Microsoft.Psi.PsiStudio
         private RelayCommand moveSelectionToNextAnnotationCommand;
         private RelayCommand clearSelectionCommand;
         private RelayCommand moveToSelectionStartCommand;
-        private RelayCommand togglePlayRepeatCommand;
         private RelayCommand moveToSelectionEndCommand;
         private RelayCommand increasePlaySpeedCommand;
         private RelayCommand decreasePlaySpeedCommand;
@@ -569,16 +568,6 @@ namespace Microsoft.Psi.PsiStudio
             => this.moveToSelectionStartCommand ??= new RelayCommand(
                 () => this.VisualizationContainer.Navigator.MoveCursorToSelectionStart(),
                 () => this.VisualizationContainer.Navigator.CanMoveCursorToSelectionStart());
-
-        /// <summary>
-        /// Gets the toggle play repeat command.
-        /// </summary>
-        [Browsable(false)]
-        [IgnoreDataMember]
-        public RelayCommand TogglePlayRepeatCommand
-            => this.togglePlayRepeatCommand ??= new RelayCommand(
-                () => this.VisualizationContainer.Navigator.RepeatPlayback = !this.VisualizationContainer.Navigator.RepeatPlayback,
-                () => VisualizationContext.Instance.IsDatasetLoaded());
 
         /// <summary>
         /// Gets the command to move the cursor to the selection end.

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Navigation/Navigator.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Navigation/Navigator.cs
@@ -903,7 +903,7 @@ namespace Microsoft.Psi.Visualization.Navigation
                 this.audioPlaybackPipeline.IsRunning &&
                 (this.playSpeed != 1.0d || !this.audioPlaybackSources.Any(s => s.Value != null)))
             {
-                // O/w if we an audio playback pipeline running and the play speed has changed from 1x or there are
+                // O/w if we have an audio playback pipeline running and the play speed has changed from 1x or there are
                 // no more audio sources to play, then stop the audio playback pipeline
                 this.audioPlaybackPipeline.PipelineExceptionNotHandled -= this.OnAudioPlaybackPipelineError;
                 this.audioPlaybackPipeline.PipelineCompleted -= this.OnAudioPlaybackPipelineCompleted;

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Navigation/Navigator.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/Navigation/Navigator.cs
@@ -43,7 +43,11 @@ namespace Microsoft.Psi.Visualization.Navigation
         private DateTime cursor;
         private CursorMode cursorMode;
 
+        private DateTime playbackStartTime = DateTime.MinValue;
+        private DateTime playbackEndTime = DateTime.MinValue;
+
         private Pipeline audioPlaybackPipeline = null;
+        private DateTime audioPlaybackDateTime = DateTime.MinValue;
 
         // The time offset of the Cursor when in Live mode from the left hand edge of the view window
         private TimeSpan liveCursorOffsetFromViewRangeStart;
@@ -62,10 +66,10 @@ namespace Microsoft.Psi.Visualization.Navigation
         // The playback speed
         private double playSpeed = 1.0d;
 
-        private DispatcherTimer playTimer = null;
+        private DispatcherTimer playbackTimer = null;
 
-        // The current clock time (in ticks) of the last time the play timer fired
-        private DateTime lastPlayTimerTickTime;
+        // The current clock time (in ticks) of the last time the playback timer fired
+        private DateTime lastPlaybackTimerTickTime;
 
         // Repeats playback in a loop if true, otherwise stops playback at the selection end marker
         private bool repeatPlayback = false;
@@ -197,7 +201,11 @@ namespace Microsoft.Psi.Visualization.Navigation
                     this.RaisePropertyChanging(nameof(this.PlaySpeed));
                     this.playSpeed = value;
                     this.RaisePropertyChanged(nameof(this.PlaySpeed));
-                    this.UpdateAudioPlayback();
+
+                    if (this.CursorMode == CursorMode.Playback)
+                    {
+                        this.UpdatePlayback();
+                    }
                 }
             }
         }
@@ -447,8 +455,11 @@ namespace Microsoft.Psi.Visualization.Navigation
         public void AddOrUpdateAudioPlaybackSource(AudioVisualizationObject audioVisualizationObject, StreamSource streamSource)
         {
             this.audioPlaybackSources[audioVisualizationObject] = streamSource;
-            this.UpdateAudioPlayback();
-            ////this.RaisePropertyChanged(nameof(this.AudioPlaybackStreams));
+
+            if (this.CursorMode == CursorMode.Playback)
+            {
+                this.UpdatePlayback();
+            }
         }
 
         /// <summary>
@@ -458,7 +469,11 @@ namespace Microsoft.Psi.Visualization.Navigation
         public void RemoveAudioPlaybackSource(AudioVisualizationObject audioVisualizationObject)
         {
             this.audioPlaybackSources.Remove(audioVisualizationObject);
-            this.UpdateAudioPlayback();
+
+            if (this.CursorMode == CursorMode.Playback)
+            {
+                this.UpdatePlayback();
+            }
         }
 
         /// <summary>
@@ -469,55 +484,42 @@ namespace Microsoft.Psi.Visualization.Navigation
         public bool IsAudioPlaybackVisualizationObject(AudioVisualizationObject audioVisualizationObject) => this.audioPlaybackSources.ContainsKey(audioVisualizationObject);
 
         /// <summary>
-        /// Sets the cursor mode.
+        /// Set the cursor mode to manual.
         /// </summary>
-        /// <param name="cursorMode">The cursor mode to set.</param>
-        public void SetCursorMode(CursorMode cursorMode)
+        public void SetManualCursorMode()
         {
-            switch (cursorMode)
+            if (this.CursorMode == CursorMode.Playback || this.CursorMode == CursorMode.Live)
             {
-                // Switch into Manual mode
-                case CursorMode.Manual:
-                    switch (this.CursorMode)
-                    {
-                        case CursorMode.Playback:
-                        case CursorMode.Live:
-                            this.StopPlayback();
-                            break;
-                    }
+                this.StopPlaybackMode();
+            }
+        }
 
-                    break;
+        /// <summary>
+        /// Set the cursor mode to playback.
+        /// </summary>
+        /// <param name="playbackStartTime">The playback start time.</param>
+        /// <param name="playbackEndTime">The playback end time.</param>
+        public void SetPlaybackCursorMode(DateTime playbackStartTime, DateTime playbackEndTime)
+        {
+            if (this.CursorMode == CursorMode.Manual || this.CursorMode == CursorMode.Live)
+            {
+                this.StartPlaybackMode(playbackStartTime, playbackEndTime);
+            }
+        }
 
-                // Switch into Playback mode
-                case CursorMode.Playback:
-                    switch (this.CursorMode)
-                    {
-                        case CursorMode.Manual:
-                        case CursorMode.Live:
-                            this.StartPlayback();
-                            break;
-                    }
-
-                    break;
-
-                // Switch into Live mode
-                case CursorMode.Live:
-                    switch (this.CursorMode)
-                    {
-                        case CursorMode.Manual:
-                            this.EnterLiveMode();
-                            break;
-
-                        case CursorMode.Playback:
-                            this.StopPlayback();
-                            this.EnterLiveMode();
-                            break;
-                    }
-
-                    break;
-
-                default:
-                    throw new ApplicationException(string.Format("Navigator.SetCursorMode() - Don't know how to handle CursorMode.{0}", cursorMode));
+        /// <summary>
+        /// Set the cursor model to live.
+        /// </summary>
+        public void SetLiveCursorMode()
+        {
+            if (this.CursorMode == CursorMode.Manual)
+            {
+                this.StartLiveMode();
+            }
+            else if (this.CursorMode == CursorMode.Playback)
+            {
+                this.StopPlaybackMode();
+                this.StartLiveMode();
             }
         }
 
@@ -794,56 +796,82 @@ namespace Microsoft.Psi.Visualization.Navigation
             this.CursorMode != CursorMode.Live && (this.SelectionRange.StartTime != DateTime.MinValue || this.SelectionRange.EndTime != DateTime.MaxValue);
 
         /// <summary>
-        /// Animates the navigator cursor based on indicated speed.
+        /// Start the playback mode for a specified time range.
         /// </summary>
-        private void StartPlayback()
+        private void StartPlaybackMode(DateTime playbackStartTime, DateTime playbackEndTime)
         {
-            // Create the play timer if it doesn't exist yet
-            this.playTimer ??= new DispatcherTimer(TimeSpan.FromMilliseconds(this.playTimerTickIntervalMs), DispatcherPriority.Background, new EventHandler(this.OnPlaytimerTick), Dispatcher.CurrentDispatcher);
+            // Set the playback start and end time
+            this.playbackStartTime = playbackStartTime;
+            this.playbackEndTime = playbackEndTime;
 
-            // Make sure that the cursor is visible
+            // Set the cursor to the playback start time and make sure it's visible
+            this.Cursor = playbackStartTime;
             this.EnsureCursorVisible();
 
-            // Update the cursor mode
+            // Update the cursor mode to playback
             this.CursorMode = CursorMode.Playback;
 
-            // Start the play timer running
-            this.lastPlayTimerTickTime = DateTime.UtcNow;
-            this.playTimer.Start();
-
-            // Start audio playback
-            this.UpdateAudioPlayback();
+            // Update the playback to the current conditions (i.e. start audio if necessary, etc.)
+            this.UpdatePlayback();
         }
 
         /// <summary>
-        /// Stop animating the navigator cursor.
+        /// Stops the playback mode and go back to manual.
         /// </summary>
-        private void StopPlayback()
+        private void StopPlaybackMode()
         {
-            // Pause the play timer
-            this.playTimer?.Stop();
+            // Pause the playback timer
+            this.playbackTimer.Stop();
 
-            // Update the cursor mode
-            this.CursorMode = CursorMode.Manual;
-
-            // Stop audio playback
-            this.UpdateAudioPlayback();
-        }
-
-        private void UpdateAudioPlayback()
-        {
-            if (this.audioPlaybackPipeline != null)
+            // If we have an audio playback pipeline that's still running
+            if (this.audioPlaybackPipeline != null && this.audioPlaybackPipeline.IsRunning)
             {
+                // Then stop the audio playback pipeline
+                this.audioPlaybackPipeline.PipelineExceptionNotHandled -= this.OnAudioPlaybackPipelineError;
+                this.audioPlaybackPipeline.PipelineCompleted -= this.OnAudioPlaybackPipelineCompleted;
                 this.audioPlaybackPipeline.Dispose();
                 this.audioPlaybackPipeline = null;
+                this.audioPlaybackDateTime = DateTime.MinValue;
             }
 
-            // If we're in playback mode, and the playback speed is 1x, and we have any bound audio streams to play back, then create the audio player
-            if ((this.CursorMode == CursorMode.Playback) && (this.playSpeed == 1.0d) && this.audioPlaybackSources.Any(s => s.Value != null))
+            // Set the cursor mode to manual
+            this.CursorMode = CursorMode.Manual;
+        }
+
+        /// <summary>
+        /// Updates the playback to the current play speed and audio sources.
+        /// </summary>
+        private void UpdatePlayback()
+        {
+            // If the playback speed is 1x, and we have any bound audio streams to play back
+            if ((this.playSpeed == 1.0d) && this.audioPlaybackSources.Any(s => s.Value != null))
             {
-                // Create the playback pipeline
-                this.audioPlaybackPipeline = Pipeline.Create("AudioPlayer");
+                // Then create or update the audio playback pipeline for the playback region
+                var audioPlaybackStartTime = this.playbackStartTime;
+                var audioPlaybackEndTime = this.playbackEndTime;
+
+                // If we have an audio playback pipeline that is currently playing
+                if (this.audioPlaybackPipeline != null && this.audioPlaybackPipeline.IsRunning)
+                {
+                    // Stop the pipeline
+                    this.audioPlaybackPipeline.PipelineExceptionNotHandled -= this.OnAudioPlaybackPipelineError;
+                    this.audioPlaybackPipeline.PipelineCompleted -= this.OnAudioPlaybackPipelineCompleted;
+                    this.audioPlaybackPipeline.Dispose();
+                    this.audioPlaybackPipeline = null;
+                    this.audioPlaybackDateTime = DateTime.MinValue;
+                }
+
+                // If we have a playback in progress (either an audio or a regular playback)
+                if (this.playbackTimer != null && this.playbackTimer.IsEnabled)
+                {
+                    // Then we will start the audio playback pipeline from the current cursor position
+                    audioPlaybackStartTime = this.Cursor;
+                }
+
+                // Now create the audio playback pipeline
+                this.audioPlaybackPipeline = Pipeline.Create($"AudioPlayer@{DateTime.Now.TimeOfDay}");
                 this.audioPlaybackPipeline.PipelineExceptionNotHandled += this.OnAudioPlaybackPipelineError;
+                this.audioPlaybackPipeline.PipelineCompleted += this.OnAudioPlaybackPipelineCompleted;
 
                 foreach (var (audio, streamSource) in this.audioPlaybackSources.Select(source => (source.Key, source.Value)))
                 {
@@ -859,24 +887,53 @@ namespace Microsoft.Psi.Visualization.Navigation
                         }
 
                         // Create the audio player
-                        var audioPlayer = new AudioPlayer(this.audioPlaybackPipeline, new AudioPlayerConfiguration());
+                        var audioPlayer = new AudioPlayer(this.audioPlaybackPipeline, new AudioPlayerConfiguration() { Format = audio.AudioFormat });
                         stream.PipeTo(audioPlayer.In);
                     }
                 }
 
+                // Update the audio playback date time based on the pipeline streaming position
+                this.audioPlaybackDateTime = DateTime.MinValue;
+                Generators.Repeat(this.audioPlaybackPipeline, 0, TimeSpan.FromMilliseconds(20)).Do((_, e) => this.audioPlaybackDateTime = e.OriginatingTime);
+
                 // Start playing back the audio
-                var endTime = this.SelectionRange.EndTime != DateTime.MaxValue ? this.SelectionRange.EndTime : this.DataRange.EndTime;
-                this.audioPlaybackPipeline.RunAsync(new ReplayDescriptor(this.Cursor, endTime));
+                this.audioPlaybackPipeline.RunAsync(new ReplayDescriptor(audioPlaybackStartTime, audioPlaybackEndTime));
+            }
+            else if (this.audioPlaybackPipeline != null &&
+                this.audioPlaybackPipeline.IsRunning &&
+                (this.playSpeed != 1.0d || !this.audioPlaybackSources.Any(s => s.Value != null)))
+            {
+                // O/w if we an audio playback pipeline running and the play speed has changed from 1x or there are
+                // no more audio sources to play, then stop the audio playback pipeline
+                this.audioPlaybackPipeline.PipelineExceptionNotHandled -= this.OnAudioPlaybackPipelineError;
+                this.audioPlaybackPipeline.PipelineCompleted -= this.OnAudioPlaybackPipelineCompleted;
+                this.audioPlaybackPipeline.Dispose();
+                this.audioPlaybackPipeline = null;
+                this.audioPlaybackDateTime = DateTime.MinValue;
+            }
+
+            // Create the playback timer if one doesn't exist already
+            this.playbackTimer ??= new DispatcherTimer(
+                TimeSpan.FromMilliseconds(this.playTimerTickIntervalMs),
+                DispatcherPriority.Background,
+                new EventHandler(this.OnPlaybackTimerTick),
+                Dispatcher.CurrentDispatcher);
+
+            // Start the playback timer if not already running
+            this.lastPlaybackTimerTickTime = DateTime.UtcNow;
+            if (!this.playbackTimer.IsEnabled)
+            {
+                this.playbackTimer.Start();
             }
         }
 
         private void OnAudioPlaybackPipelineError(object sender, PipelineExceptionNotHandledEventArgs e)
         {
-            Application.Current.Dispatcher.BeginInvoke(() =>
+            Application.Current.Dispatcher.Invoke(() =>
             {
                 if (this.audioPlaybackPipeline != null)
                 {
-                    this.StopPlayback();
+                    this.StopPlaybackMode();
 
                     new MessageBoxWindow(
                         Application.Current.MainWindow,
@@ -888,10 +945,29 @@ namespace Microsoft.Psi.Visualization.Navigation
             });
         }
 
+        private void OnAudioPlaybackPipelineCompleted(object sender, PipelineCompletedEventArgs e)
+        {
+            // If Repeat is enabled, then restart the playback, o/w stop it.
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                // If looping playback is enabled
+                if (this.RepeatPlayback)
+                {
+                    // Then clear out the audio playback pipeline and restart the playback
+                    this.StartPlaybackMode(this.playbackStartTime, this.playbackEndTime);
+                }
+                else
+                {
+                    // O/w stop the playback
+                    this.StopPlaybackMode();
+                }
+            });
+        }
+
         /// <summary>
         /// Sets the cursor mode to live.
         /// </summary>
-        private void EnterLiveMode()
+        private void StartLiveMode()
         {
             // Update the cursor mode
             this.CursorMode = CursorMode.Live;
@@ -903,39 +979,45 @@ namespace Microsoft.Psi.Visualization.Navigation
             }
         }
 
-        private void OnPlaytimerTick(object sender, EventArgs e)
+        private void OnPlaybackTimerTick(object sender, EventArgs e)
         {
-            // Calculate the new cursor position
-            DateTime now = DateTime.UtcNow;
-            this.Cursor = this.Cursor.AddTicks((long)((now - this.lastPlayTimerTickTime).Ticks * this.playSpeed));
+            // Update the cursor position based on audio playback pipeline or playback timer
 
-            // Check if we've hit the end of the selection (or of the data)
-            var endTime = this.SelectionRange.EndTime != DateTime.MaxValue ? this.SelectionRange.EndTime : this.DataRange.EndTime;
-            if (this.Cursor >= endTime)
+            // If we have audio playback running
+            if (this.audioPlaybackPipeline != null)
             {
-                // If Repeat is enabled, then move the cursor back to the
-                // selection start marker, otherwise stop the play timer
+                // Calculate the cursor position based on the audio playback
+                if (this.audioPlaybackDateTime != DateTime.MinValue)
+                {
+                    this.Cursor = this.audioPlaybackDateTime;
+                }
+            }
+            else
+            {
+                // O/w calculate the new cursor position according to the playback timer
+                var now = DateTime.UtcNow;
+                this.Cursor = this.Cursor.AddTicks((long)((now - this.lastPlaybackTimerTickTime).Ticks * this.playSpeed));
+                this.lastPlaybackTimerTickTime = now;
+            }
+
+            // Make sure the view window adjust to keep the cursor visible
+            this.EnsureCursorVisible();
+
+            // Check if we're at the end of the playback range
+            if (this.Cursor > this.playbackEndTime)
+            {
+                // If looping playback is enabled
                 if (this.RepeatPlayback)
                 {
-                    this.Cursor = this.SelectionRange.StartTime != DateTime.MinValue ? this.SelectionRange.StartTime : this.DataRange.StartTime;
-                    this.EnsureCursorVisible();
-                    this.UpdateAudioPlayback();
+                    // Then clear out the audio playback pipeline and restart the playback
+                    this.StartPlaybackMode(this.playbackStartTime, this.playbackEndTime);
                 }
                 else
                 {
-                    this.Cursor = endTime;
-                    this.playTimer.Stop();
-                    this.CursorMode = CursorMode.Manual;
+                    // O/w stop the playback
+                    this.StopPlaybackMode();
                 }
             }
-
-            // Make sure the cursor is visible in the view window
-            if (this.Cursor > this.ViewRange.EndTime)
-            {
-                this.ViewRange.Set(this.Cursor, this.ViewRange.Duration);
-            }
-
-            this.lastPlayTimerTickTime = now;
         }
 
         private void EnsureCursorVisible()

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/ViewModels/PartitionViewModel.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/ViewModels/PartitionViewModel.cs
@@ -380,8 +380,6 @@ namespace Microsoft.Psi.Visualization.ViewModels
                 this.newMetadataCallback = new UpdateStreamMetadataDelegate(this.UpdateStreamMetadata);
                 this.MonitorLivePartition();
             }
-
-            this.IsTreeNodeExpanded = true;
         }
 
         /// <summary>

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/ViewModels/SessionViewModel.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/ViewModels/SessionViewModel.cs
@@ -692,16 +692,26 @@ namespace Microsoft.Psi.Visualization.ViewModels
             var runTasksMenuItem = MenuItemHelper.CreateMenuItem(string.Empty, "Run Batch Processing Task", null);
             var batchProcessingTasks = VisualizationContext.Instance.PluginMap.BatchProcessingTasks;
             runTasksMenuItem.IsEnabled = batchProcessingTasks.Any();
-            foreach (var batchProcessingTask in batchProcessingTasks)
+            foreach (var batchProcessingTaskNamespace in batchProcessingTasks.Select(bpt => bpt.Namespace).Distinct())
             {
-                runTasksMenuItem.Items.Add(
-                    MenuItemHelper.CreateMenuItem(
-                        batchProcessingTask.IconSourcePath,
-                        batchProcessingTask.Name,
-                        new VisualizationCommand<BatchProcessingTaskMetadata>(async bpt => await VisualizationContext.Instance.RunSessionBatchProcessingTask(this, bpt)),
-                        tag: batchProcessingTask,
-                        isEnabled: true,
-                        commandParameter: batchProcessingTask));
+                var namespaceMenuItem = MenuItemHelper.CreateMenuItem(
+                    null,
+                    batchProcessingTaskNamespace,
+                    null);
+
+                foreach (var batchProcessingTask in batchProcessingTasks.Where(bpt => bpt.Namespace == batchProcessingTaskNamespace))
+                {
+                    namespaceMenuItem.Items.Add(
+                        MenuItemHelper.CreateMenuItem(
+                            batchProcessingTask.IconSourcePath,
+                            batchProcessingTask.Name,
+                            new VisualizationCommand<BatchProcessingTaskMetadata>(async bpt => await VisualizationContext.Instance.RunSessionBatchProcessingTask(this, bpt)),
+                            tag: batchProcessingTask,
+                            isEnabled: true,
+                            commandParameter: batchProcessingTask));
+                }
+
+                runTasksMenuItem.Items.Add(namespaceMenuItem);
             }
 
             contextMenu.Items.Add(runTasksMenuItem);

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/ViewModels/StreamTreeNode.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/ViewModels/StreamTreeNode.cs
@@ -1436,6 +1436,15 @@ namespace Microsoft.Psi.Visualization.ViewModels
                 copyToClipboardMenuItem.Items.Add(
                     MenuItemHelper.CreateMenuItem(
                         null,
+                        "[Partition Name]:Stream Name",
+                        VisualizationContext.Instance.VisualizationContainer.Navigator.CopyToClipboardCommand,
+                        null,
+                        true,
+                        $"[{this.PartitionViewModel.Name}]:{this.FullName}"));
+
+                copyToClipboardMenuItem.Items.Add(
+                    MenuItemHelper.CreateMenuItem(
+                        null,
                         "Source Stream Name",
                         VisualizationContext.Instance.VisualizationContainer.Navigator.CopyToClipboardCommand,
                         null,

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/VisualizationContext.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/VisualizationContext.cs
@@ -382,25 +382,43 @@ namespace Microsoft.Psi.Visualization
             switch (this.VisualizationContainer.Navigator.CursorMode)
             {
                 case CursorMode.Playback:
-                    this.VisualizationContainer.Navigator.SetCursorMode(CursorMode.Manual);
+                    this.VisualizationContainer.Navigator.SetManualCursorMode();
                     break;
+
                 case CursorMode.Manual:
 
-                    if (fromSelectionStart)
+                    if (this.VisualizationContainer.Navigator.DataRange != null &&
+                        this.VisualizationContainer.Navigator.DataRange.StartTime != DateTime.MinValue &&
+                        this.VisualizationContainer.Navigator.DataRange.EndTime != DateTime.MaxValue)
                     {
-                        if (this.VisualizationContainer.Navigator.SelectionRange != null &&
-                            this.VisualizationContainer.Navigator.SelectionRange.StartTime != DateTime.MinValue)
+                        var playbackStartTime = this.VisualizationContainer.Navigator.DataRange.StartTime;
+                        var playbackEndTime = this.VisualizationContainer.Navigator.DataRange.EndTime;
+
+                        if (fromSelectionStart)
                         {
-                            this.VisualizationContainer.Navigator.Cursor = this.VisualizationContainer.Navigator.SelectionRange.StartTime;
+                            if (this.VisualizationContainer.Navigator.SelectionRange != null &&
+                                this.VisualizationContainer.Navigator.SelectionRange.StartTime != DateTime.MinValue)
+                            {
+                                playbackStartTime = this.VisualizationContainer.Navigator.SelectionRange.StartTime;
+                            }
+
+                            if (this.VisualizationContainer.Navigator.SelectionRange != null &&
+                                this.VisualizationContainer.Navigator.SelectionRange.EndTime != DateTime.MaxValue)
+                            {
+                                playbackEndTime = this.VisualizationContainer.Navigator.SelectionRange.EndTime;
+                            }
                         }
-                        else if (this.VisualizationContainer.Navigator.DataRange != null &&
-                            this.VisualizationContainer.Navigator.DataRange.StartTime != DateTime.MinValue)
+                        else
                         {
-                            this.VisualizationContainer.Navigator.Cursor = this.VisualizationContainer.Navigator.DataRange.StartTime;
+                            // O/w if we're playing from cursor, set the repeat flag to false
+                            playbackStartTime = this.VisualizationContainer.Navigator.Cursor;
+                            playbackEndTime = this.VisualizationContainer.Navigator.DataRange.EndTime;
+                            this.VisualizationContainer.Navigator.RepeatPlayback = false;
                         }
+
+                        this.VisualizationContainer.Navigator.SetPlaybackCursorMode(playbackStartTime, playbackEndTime);
                     }
 
-                    this.VisualizationContainer.Navigator.SetCursorMode(CursorMode.Playback);
                     break;
             }
         }
@@ -422,11 +440,11 @@ namespace Microsoft.Psi.Visualization
             // Only enter live mode if the current session contains live partitions
             if (this.DatasetViewModel != null && this.DatasetViewModel.CurrentSessionViewModel.ContainsLivePartitions && this.VisualizationContainer.Navigator.CursorMode != CursorMode.Live)
             {
-                this.VisualizationContainer.Navigator.SetCursorMode(CursorMode.Live);
+                this.VisualizationContainer.Navigator.SetLiveCursorMode();
             }
             else
             {
-                this.VisualizationContainer.Navigator.SetCursorMode(CursorMode.Manual);
+                this.VisualizationContainer.Navigator.SetManualCursorMode();
             }
         }
 
@@ -536,7 +554,7 @@ namespace Microsoft.Psi.Visualization
                 // If there are no longer any live partitions, exit live mode
                 if ((this.DatasetViewModel.CurrentSessionViewModel?.ContainsLivePartitions == false) && (this.VisualizationContainer.Navigator.CursorMode == CursorMode.Live))
                 {
-                    this.VisualizationContainer.Navigator.SetCursorMode(CursorMode.Manual);
+                    this.VisualizationContainer.Navigator.SetManualCursorMode();
                 }
             }
         }

--- a/Sources/Visualization/Microsoft.Psi.Visualization.Windows/VisualizationObjects/VisualizationContainer.cs
+++ b/Sources/Visualization/Microsoft.Psi.Visualization.Windows/VisualizationObjects/VisualizationContainer.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Psi.Visualization.VisualizationObjects
         public void Dispose()
         {
             // Ensure playback is stopped
-            this.Navigator.SetCursorMode(CursorMode.Manual);
+            this.Navigator.SetManualCursorMode();
 
             // Clear container to give all panels a chance to clean up
             this.Clear();


### PR DESCRIPTION
### __Change to SIGMA__
* Fixed issues with moving to the previous step.
* Added support for using specific synthesis voices via the Sigma client configuration.
* Updated the Sigma app to use caching for speech synthesis.

### __Changes to Components__
* Added `SpeechSynthesisCache` component to `Microsoft.Psi.Speech` to implement a cache for generated speech synthesis content.
* The Azure-based `SpeechSynthesizer` component from `Microsoft.Psi.CognitiveServices.Speech` can now cache the generated utterances for future use (future identical requests do not need to go to the cloud, speeding up synthesis). The developer can also now select (via configuration) whether the audio buffers are streamed in real-time or as they arrive, and how close ahead of real time the generated audio buffers are streamed. These options allow for better controlling playback and avoiding drops.

### __Changes to Audio__
* Added a `Streamline` operator for audio streams that allows for normalizing gaps and overlaps in the audio buffer stream based on different methods (Concatenate, Pleat, Unpleat)
* Added a batch processing task for exporting audio streams to wav files

### __Changes to PsiStudio and Visualization__
* Improved robustness of audio playback and addressed a number of issues that created drift between audio and visual playback.
* Run batch task processing menu is now split into submenus by batch task processing namespace.
* Added ability to export audio streams (or selections thereof) to a wav file.

### __Changes to Microsoft.Psi.Data__
* Added a `SessionImporter.OpenStream` overload that allows for providing a `[PartitionName]:StreamName` stream specification. This simplifies the configuration of batch processing tasks where input streams need to be specified, eliminating the need for specifying the partition separately. The existing batch tasks were adjusted to leverage this feature.

### __Changes to Runtime__
* Introduced `Merge` interval operator to compute a non-overlapping set of intervals that covers a given set of (potentially overlapping intervals)