### PR TITLE
Update InteropTests.cs

### DIFF
--- a/Sources/Runtime/Microsoft.Psi.Interop/Microsoft.Psi.Interop.csproj
+++ b/Sources/Runtime/Microsoft.Psi.Interop/Microsoft.Psi.Interop.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="15.0.0" />
-    <PackageReference Include="MessagePack" Version="2.1.90" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Sources/Runtime/Test.Psi/InteropTests.cs
+++ b/Sources/Runtime/Test.Psi/InteropTests.cs
@@ -186,7 +186,7 @@ namespace Test.Psi
             this.AssertBinarySerialization(true, msg, msg);
             this.AssertBinarySerialization(2.71828, msg, msg);
             this.AssertBinarySerialization("Howdy", msg, msg);
-            this.AssertBinarySerialization(new[] { 1, 2, 3 }, msg, msg);
+            this.AssertBinarySerialization(new object[] { 1, 2, 3 }, msg, msg);
 
             var structured = new
             {


### PR DESCRIPTION
Fixed unit test to work with latest version of MessagePack by making test data type an object[] rather than int[] to ensure that the roundtrip binary serialization test passes.